### PR TITLE
Fix TS definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,11 +6,13 @@ import fastify = require('fastify');
 
 type originCallback = (err: Error, allow: boolean) => void;
 
+type originFunction = (origin: string, callback: originCallback) => void;
+
 declare const fastifyCors: fastify.Plugin<Server, IncomingMessage, ServerResponse, {
     /**
      * Configures the Access-Control-Allow-Origin CORS header.
      */
-    origin?: string | boolean | RegExp | string[] | RegExp[] | originCallback;
+    origin?: string | boolean | RegExp | string[] | RegExp[] | originFunction;
     /**
      * Configures the Access-Control-Allow-Credentials CORS header.
      * Set to true to pass the header, otherwise it is omitted.

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -76,8 +76,12 @@ app.register(fastifyCors, {
 })
 
 app.register(fastifyCors, {
-  origin: (err: Error, allow: boolean) => {
-    throw err
+  origin: (origin: string, cb: Function) => {
+    if (/localhost/.test(origin)) {
+      cb(null, true)
+      return
+    }
+    cb(new Error(), false)
   },
   allowedHeaders: ['authorization', 'content-type'],
   methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],


### PR DESCRIPTION
This PR solve issue #23. Misleading type definition makes a custom function for `origin` options doesn't work.
