### PR TITLE
hide options route from the documentation built using fastify-swagger

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ You can use it as is without passing any option, or you can configure it as expl
 * `preflightContinue`: Pass the CORS preflight response to the route handler (default: `false`).
 * `optionsSuccessStatus`: Provides a status code to use for successful `OPTIONS` requests, since some legacy browsers (IE11, various SmartTVs) choke on `204`.
 * `preflight`: if needed you can entirely disable preflight by passing `false` here (default: `true`).
+* `hideOptionsRoute`: hide options route from the documentation built using [fastify-swagger](https://github.com/fastify/fastify-swagger) (default: `true`).
 
 ## Acknowledgements
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -56,6 +56,10 @@ declare const fastifyCors: fastify.Plugin<Server, IncomingMessage, ServerRespons
      * Pass the CORS preflight response to the route handler (default: false).
      */
     preflight?: boolean;
+    /**
+     * Hide options route from the documentation built using fastify-swagger (default: true).
+     */
+    hideOptionsRoute?: boolean;
 }>
 
 export = fastifyCors;

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ function fastifyCors (fastify, opts, next) {
     maxAge,
     preflightContinue,
     optionsSuccessStatus,
-    preflight
+    preflight,
+    hideOptionsRoute
   } = Object.assign({
     origin: '*',
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
@@ -23,7 +24,8 @@ function fastifyCors (fastify, opts, next) {
     exposedHeaders: null,
     allowedHeaders: null,
     maxAge: null,
-    preflight: true
+    preflight: true,
+    hideOptionsRoute: true
   }, opts)
 
   const isOriginFalsy = !origin
@@ -31,7 +33,7 @@ function fastifyCors (fastify, opts, next) {
   const isOriginFunction = typeof origin === 'function'
 
   if (preflight === true) {
-    fastify.options('*', (req, reply) => reply.send())
+    fastify.options('*', { schema: { hide: hideOptionsRoute } }, (req, reply) => reply.send())
   }
   fastify.addHook('onRequest', onRequest)
   function onRequest (req, reply, next) {

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -505,3 +505,20 @@ test('Disable preflight', t => {
     })
   })
 })
+
+test('show options route', t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  fastify.register(cors, { hideOptionsRoute: false })
+
+  fastify.addHook('onRoute', (route) => {
+    if (route.method === 'OPTIONS' && route.url === '*') {
+      t.strictEqual(route.schema.hide, false)
+    }
+  })
+
+  fastify.ready(err => {
+    t.error(err)
+  })
+})


### PR DESCRIPTION
This PR adds the possibility to hide the options route (that is used for preflight requests) from the documentation built using fastify-swagger