### PR TITLE
refactor(types) Tweaked the TypeScript definitions to allow for regex and strings to be mixed

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,11 +8,17 @@ type originCallback = (err: Error, allow: boolean) => void;
 
 type originFunction = (origin: string, callback: originCallback) => void;
 
+type originType = string | boolean | RegExp;
+
+type ValueOrArray<T> = T | ArrayOfValueOrArray<T>;
+
+interface ArrayOfValueOrArray<T> extends Array<ValueOrArray<T>> {}
+
 declare const fastifyCors: fastify.Plugin<Server, IncomingMessage, ServerResponse, {
     /**
      * Configures the Access-Control-Allow-Origin CORS header.
      */
-    origin?: string | boolean | RegExp | string[] | RegExp[] | originFunction;
+    origin?: ValueOrArray<originType> | originFunction;
     /**
      * Configures the Access-Control-Allow-Credentials CORS header.
      * Set to true to pass the header, otherwise it is omitted.
@@ -60,6 +66,6 @@ declare const fastifyCors: fastify.Plugin<Server, IncomingMessage, ServerRespons
      * Hide options route from the documentation built using fastify-swagger (default: true).
      */
     hideOptionsRoute?: boolean;
-}>
+}>;
 
 export = fastifyCors;


### PR DESCRIPTION
Tweaked the TypeScript definitions to allow for regex and strings to be mixed in an array, and in fact allowed the full range of what "origin" could actually handle (i.e. nested arrays, and/or an array that has a boolean at some point).

NOTE: TypeScript 3.7 allows for a simpler recursive type definition, but to enable this fix for projects using earlier TS versions, the older approach - with a helper interface - is used.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [N/A] tests and/or benchmarks are included
- [N/A] documentation is changed or added
- [?] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md) (This information doesn't appear there, though I've followed what seems like the convention from other commits)
