### PR TITLE
Allow originCallback null as first param in TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,17 @@ You can use it as is without passing any option, or you can configure it as expl
   - `String` - set `origin` to a specific origin. For example if you set it to `"http://example.com"` only requests from "http://example.com" will be allowed.
   - `RegExp` - set `origin` to a regular expression pattern which will be used to test the request origin. If it's a match, the request origin will be reflected. For example the pattern `/example\.com$/` will reflect any request that is coming from an origin ending with "example.com".
   - `Array` - set `origin` to an array of valid origins. Each origin can be a `String` or a `RegExp`. For example `["http://example1.com", /\.example2\.com$/]` will accept any request from "http://example1.com" or from a subdomain of "example2.com".
-  - `Function` - set `origin` to a function implementing some custom logic. The function takes the request origin as the first parameter and a callback as a second (which expects the signature `err [object], allow [bool]`), *async-await* and promises are supported as well. Fastify instance is bound to function call and you may access via `this`.
+  - `Function` - set `origin` to a function implementing some custom logic. The function takes the request origin as the first parameter and a callback as a second (which expects the signature `err [Error | null], allow [bool]`), *async-await* and promises are supported as well. Fastify instance is bound to function call and you may access via `this`. For example: 
+  ```js
+  origin: (origin, cb) => {
+    if(/localhost/.test(origin)){
+      //  Request from localhost will pass
+      cb(null, true)
+      return
+    }
+    cb(new Error("Not allowed"), false)
+  }
+  ```
 * `methods`: Configures the **Access-Control-Allow-Methods** CORS header. Expects a comma-delimited string (ex: 'GET,PUT,POST') or an array (ex: `['GET', 'PUT', 'POST']`).
 * `allowedHeaders`: Configures the **Access-Control-Allow-Headers** CORS header. Expects a comma-delimited string (ex: `'Content-Type,Authorization'`) or an array (ex: `['Content-Type', 'Authorization']`). If not specified, defaults to reflecting the headers specified in the request's **Access-Control-Request-Headers** header.
 * `exposedHeaders`: Configures the **Access-Control-Expose-Headers** CORS header. Expects a comma-delimited string (ex: `'Content-Range,X-Content-Range'`) or an array (ex: `['Content-Range', 'X-Content-Range']`). If not specified, no custom headers are exposed.

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ import { Server, IncomingMessage, ServerResponse } from 'http'
 
 import fastify = require('fastify');
 
-type originCallback = (err: Error, allow: boolean) => void;
+type originCallback = (err: Error | null, allow: boolean) => void;
 
 type originFunction = (origin: string, callback: originCallback) => void;
 

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -76,8 +76,8 @@ app.register(fastifyCors, {
 })
 
 app.register(fastifyCors, {
-  origin: (origin: string, cb: Function) => {
-    if (/localhost/.test(origin)) {
+  origin: (origin: string, cb: (err: Error | null, allow: boolean) => void) => {
+    if (/localhost/.test(origin) || typeof origin === 'undefined') {
       cb(null, true)
       return
     }


### PR DESCRIPTION
This pull request updates the TS type for the origin callback function to allow null as a first parameter for the callback (issue #53), this was previously requested on PR #54 but instead of changing the `originFunction` type, I propose to change the `originCallback` type. Documentation and tests have been updated as well.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
