### PR TITLE
Add http2 server support on TypeScript type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 // Definitions by: Jannik Keye <https://github.com/jannikkeye>
 
 import { Server, IncomingMessage, ServerResponse } from 'http'
+import { Http2Server, Http2ServerRequest, Http2ServerResponse } from 'http2'
 
 import fastify = require('fastify');
 
@@ -14,58 +15,63 @@ type ValueOrArray<T> = T | ArrayOfValueOrArray<T>;
 
 interface ArrayOfValueOrArray<T> extends Array<ValueOrArray<T>> {}
 
-declare const fastifyCors: fastify.Plugin<Server, IncomingMessage, ServerResponse, {
-    /**
-     * Configures the Access-Control-Allow-Origin CORS header.
-     */
-    origin?: ValueOrArray<originType> | originFunction;
-    /**
-     * Configures the Access-Control-Allow-Credentials CORS header.
-     * Set to true to pass the header, otherwise it is omitted.
-     */
-    credentials?: boolean;
-    /**
-     * Configures the Access-Control-Expose-Headers CORS header.
-     * Expects a comma-delimited string (ex: 'Content-Range,X-Content-Range')
-     * or an array (ex: ['Content-Range', 'X-Content-Range']).
-     * If not specified, no custom headers are exposed.
-     */
-    exposedHeaders?: string | string[];
-    /**
-     * Configures the Access-Control-Allow-Headers CORS header.
-     * Expects a comma-delimited string (ex: 'Content-Type,Authorization')
-     * or an array (ex: ['Content-Type', 'Authorization']). If not
-     * specified, defaults to reflecting the headers specified in the
-     * request's Access-Control-Request-Headers header.
-     */
-    allowedHeaders?: string | string[];
-    /**
-     * Configures the Access-Control-Allow-Methods CORS header.
-     * Expects a comma-delimited string (ex: 'GET,PUT,POST') or an array (ex: ['GET', 'PUT', 'POST']).
-     */
-    methods?: string | string[];
-    /**
-     * Configures the Access-Control-Max-Age CORS header.
-     * Set to an integer to pass the header, otherwise it is omitted.
-     */
-    maxAge?: number;
-    /**
-     * Pass the CORS preflight response to the route handler (default: false).
-     */
-    preflightContinue?: boolean;
-    /**
-     * Provides a status code to use for successful OPTIONS requests,
-     * since some legacy browsers (IE11, various SmartTVs) choke on 204.
-     */
-    optionsSuccessStatus?: number;
-    /**
-     * Pass the CORS preflight response to the route handler (default: false).
-     */
-    preflight?: boolean;
-    /**
-     * Hide options route from the documentation built using fastify-swagger (default: true).
-     */
-    hideOptionsRoute?: boolean;
-}>;
+declare const fastifyCors: fastify.Plugin<
+    Server | Http2Server,
+    IncomingMessage | Http2ServerRequest,
+    ServerResponse | Http2ServerResponse,
+    {
+        /**
+         * Configures the Access-Control-Allow-Origin CORS header.
+         */
+        origin?: ValueOrArray<originType> | originFunction;
+        /**
+         * Configures the Access-Control-Allow-Credentials CORS header.
+         * Set to true to pass the header, otherwise it is omitted.
+         */
+        credentials?: boolean;
+        /**
+         * Configures the Access-Control-Expose-Headers CORS header.
+         * Expects a comma-delimited string (ex: 'Content-Range,X-Content-Range')
+         * or an array (ex: ['Content-Range', 'X-Content-Range']).
+         * If not specified, no custom headers are exposed.
+         */
+        exposedHeaders?: string | string[];
+        /**
+         * Configures the Access-Control-Allow-Headers CORS header.
+         * Expects a comma-delimited string (ex: 'Content-Type,Authorization')
+         * or an array (ex: ['Content-Type', 'Authorization']). If not
+         * specified, defaults to reflecting the headers specified in the
+         * request's Access-Control-Request-Headers header.
+         */
+        allowedHeaders?: string | string[];
+        /**
+         * Configures the Access-Control-Allow-Methods CORS header.
+         * Expects a comma-delimited string (ex: 'GET,PUT,POST') or an array (ex: ['GET', 'PUT', 'POST']).
+         */
+        methods?: string | string[];
+        /**
+         * Configures the Access-Control-Max-Age CORS header.
+         * Set to an integer to pass the header, otherwise it is omitted.
+         */
+        maxAge?: number;
+        /**
+         * Pass the CORS preflight response to the route handler (default: false).
+         */
+        preflightContinue?: boolean;
+        /**
+         * Provides a status code to use for successful OPTIONS requests,
+         * since some legacy browsers (IE11, various SmartTVs) choke on 204.
+         */
+        optionsSuccessStatus?: number;
+        /**
+         * Pass the CORS preflight response to the route handler (default: false).
+         */
+        preflight?: boolean;
+        /**
+         * Hide options route from the documentation built using fastify-swagger (default: true).
+         */
+        hideOptionsRoute?: boolean;
+    }
+>;
 
 export = fastifyCors;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 // Definitions by: Jannik Keye <https://github.com/jannikkeye>
 
 import { Server, IncomingMessage, ServerResponse } from 'http'
-import { Http2Server, Http2ServerRequest, Http2ServerResponse } from 'http2'
+import { Http2SecureServer, Http2Server, Http2ServerRequest, Http2ServerResponse } from 'http2'
 
 import fastify = require('fastify');
 
@@ -16,7 +16,7 @@ type ValueOrArray<T> = T | ArrayOfValueOrArray<T>;
 interface ArrayOfValueOrArray<T> extends Array<ValueOrArray<T>> {}
 
 declare const fastifyCors: fastify.Plugin<
-    Server | Http2Server,
+    Server | Http2Server | Http2SecureServer,
     IncomingMessage | Http2ServerRequest,
     ServerResponse | Http2ServerResponse,
     {

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -3,6 +3,8 @@ import * as fastifyCors from '../..'
 
 const app = Fastify()
 
+app.register(fastifyCors)
+
 app.register(fastifyCors, {
   origin: true,
   allowedHeaders: 'authorization,content-type',
@@ -76,6 +78,100 @@ app.register(fastifyCors, {
 })
 
 app.register(fastifyCors, {
+  origin: (origin: string, cb: (err: Error | null, allow: boolean) => void) => {
+    if (/localhost/.test(origin) || typeof origin === 'undefined') {
+      cb(null, true)
+      return
+    }
+    cb(new Error(), false)
+  },
+  allowedHeaders: ['authorization', 'content-type'],
+  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+  credentials: true,
+  exposedHeaders: ['authorization'],
+  maxAge: 13000,
+  preflightContinue: false,
+  optionsSuccessStatus: 200,
+  preflight: false
+})
+
+const appHttp2 = Fastify({ http2: true })
+
+appHttp2.register(fastifyCors)
+
+appHttp2.register(fastifyCors, {
+  origin: true,
+  allowedHeaders: 'authorization,content-type',
+  methods: 'GET,POST,PUT,PATCH,DELETE,OPTIONS',
+  credentials: true,
+  exposedHeaders: 'authorization',
+  maxAge: 13000,
+  preflightContinue: false,
+  optionsSuccessStatus: 200,
+  preflight: false
+})
+
+appHttp2.register(fastifyCors, {
+  origin: true,
+  allowedHeaders: ['authorization', 'content-type'],
+  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+  credentials: true,
+  exposedHeaders: ['authorization'],
+  maxAge: 13000,
+  preflightContinue: false,
+  optionsSuccessStatus: 200,
+  preflight: false
+})
+
+appHttp2.register(fastifyCors, {
+  origin: '*',
+  allowedHeaders: ['authorization', 'content-type'],
+  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+  credentials: true,
+  exposedHeaders: ['authorization'],
+  maxAge: 13000,
+  preflightContinue: false,
+  optionsSuccessStatus: 200,
+  preflight: false
+})
+
+appHttp2.register(fastifyCors, {
+  origin: /\*/,
+  allowedHeaders: ['authorization', 'content-type'],
+  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+  credentials: true,
+  exposedHeaders: ['authorization'],
+  maxAge: 13000,
+  preflightContinue: false,
+  optionsSuccessStatus: 200,
+  preflight: false
+})
+
+appHttp2.register(fastifyCors, {
+  origin: ['*', 'something'],
+  allowedHeaders: ['authorization', 'content-type'],
+  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+  credentials: true,
+  exposedHeaders: ['authorization'],
+  maxAge: 13000,
+  preflightContinue: false,
+  optionsSuccessStatus: 200,
+  preflight: false
+})
+
+appHttp2.register(fastifyCors, {
+  origin: [/\*/, /something/],
+  allowedHeaders: ['authorization', 'content-type'],
+  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+  credentials: true,
+  exposedHeaders: ['authorization'],
+  maxAge: 13000,
+  preflightContinue: false,
+  optionsSuccessStatus: 200,
+  preflight: false
+})
+
+appHttp2.register(fastifyCors, {
   origin: (origin: string, cb: (err: Error | null, allow: boolean) => void) => {
     if (/localhost/.test(origin) || typeof origin === 'undefined') {
       cb(null, true)


### PR DESCRIPTION
I had trouble with TypeScript when using fatify-cors with a http2 fastify server. The cors headers are correctly set. The problem is only a types incompatibility between Node http and http2 servers. This fixes it by allowing both server types.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
