### PR TITLE
Fix Fastify version typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 `fastify-cors` enables the use of [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) in a Fastify application.
 
 Supports Fastify versions `3.x`
-Please refer to [this branch](https://github.com/fastify/fastify-cors/tree/3.x) and related versions for Fastify `^3.x` compatibility.
+Please refer to [this branch](https://github.com/fastify/fastify-cors/tree/3.x) and related versions for Fastify `^2.x` compatibility.
 Please refer to [this branch](https://github.com/fastify/fastify-cors/tree/1.x) and related versions for Fastify `^1.x` compatibility.
 
 ## Install


### PR DESCRIPTION
Just a small documentation typo, the `fastify-cors` v3 is actually for use with `fastify` v2. Before it was suggesting support for `fastify` v3.