### PR TITLE
WIP: feat: add strictPreflight option

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,8 @@ function fastifyCors (fastify, opts, next) {
     preflightContinue,
     optionsSuccessStatus,
     preflight,
-    hideOptionsRoute
+    hideOptionsRoute,
+    strictPreflight
   } = Object.assign({
     origin: '*',
     methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
@@ -25,7 +26,8 @@ function fastifyCors (fastify, opts, next) {
     allowedHeaders: null,
     maxAge: null,
     preflight: true,
-    hideOptionsRoute: true
+    hideOptionsRoute: true,
+    strictPreflight: false
   }, opts)
 
   const isOriginFalsy = !origin
@@ -60,6 +62,11 @@ function fastifyCors (fastify, opts, next) {
 
       if (req.raw.method === 'OPTIONS' && preflight === true) {
         // preflight
+        if (strictPreflight === true && (!req.headers.origin || !req.headers['access-control-request-method'])) {
+          reply.status(400).send('Invalid preflight request')
+          return
+        }
+
         reply.header(
           'Access-Control-Allow-Methods',
           Array.isArray(methods) ? methods.join(', ') : methods


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added **TODO**
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This is a new feature that attempts to resolve the issue revealed in #88 .

This PR introduces a new option `strictPreflight` that will enforce the origin and access-control-request-method headers on preflight options requests.

Notably, _this does not implement the solution proposed by the author of the issue_. Instead, it will result in a 400 response if preflight requests do not have the required headers. This aligns the fastify-cors plugin with the now superseded [w3c specification describing the preflight workflow](https://www.w3.org/TR/2020/SPSD-cors-20200602/#resource-preflight-requests).

The superseded spec states that when the headers are missing the preflight processing should:

>  ... terminate this set of steps. The request is outside the scope of this specification.

The new [fetch spec](https://fetch.spec.whatwg.org/#cors-preflight-request) does not indicate what the behavior should be if the headers are missing.

Finally, while investigating this issue, I compared the current behavior of fastify-cors with express cors. **Fastify-cors behaves in the same way as express cors.** This is the motivation for introducing the new option that would allow consumers of the plugin to opt-in to stricter handling of the preflight headers.