### PR TITLE
chore: refactor for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can use it as is without passing any option, or you can configure it as expl
   - `String` - set `origin` to a specific origin. For example if you set it to `"http://example.com"` only requests from "http://example.com" will be allowed.
   - `RegExp` - set `origin` to a regular expression pattern which will be used to test the request origin. If it's a match, the request origin will be reflected. For example the pattern `/example\.com$/` will reflect any request that is coming from an origin ending with "example.com".
   - `Array` - set `origin` to an array of valid origins. Each origin can be a `String` or a `RegExp`. For example `["http://example1.com", /\.example2\.com$/]` will accept any request from "http://example1.com" or from a subdomain of "example2.com".
-  - `Function` - set `origin` to a function implementing some custom logic. The function takes the request origin as the first parameter and a callback as a second (which expects the signature `err [Error | null], allow [bool]`), *async-await* and promises are supported as well. Fastify instance is bound to function call and you may access via `this`. For example: 
+  - `Function` - set `origin` to a function implementing some custom logic. The function takes the request origin as the first parameter and a callback as a second (which expects the signature `err [Error | null], origin`), where `origin` is a non function value of the origin option. *Async-await* and promises are supported as well. The Fastify instance is bound to function call and you may access via `this`. For example: 
   ```js
   origin: (origin, cb) => {
     if(/localhost/.test(origin)){
@@ -43,7 +43,8 @@ You can use it as is without passing any option, or you can configure it as expl
       cb(null, true)
       return
     }
-    cb(new Error("Not allowed"), false)
+    // Generate an error on other origins, disabling access
+    cb(new Error("Not allowed"))
   }
   ```
 * `methods`: Configures the **Access-Control-Allow-Methods** CORS header. Expects a comma-delimited string (ex: 'GET,PUT,POST') or an array (ex: `['GET', 'PUT', 'POST']`).

--- a/index.js
+++ b/index.js
@@ -127,19 +127,11 @@ function fastifyCors (fastify, opts, next) {
   }
 
   async function resolveOriginWrapper (req, cb) {
-    try {
-      const result = origin.call(fastify, req.headers.origin, cb)
+    const result = origin.call(fastify, req.headers.origin, cb)
 
-      // Allow for promises
-      if (result && typeof result.then === 'function') {
-        try {
-          return cb(null, await result)
-        } catch (error) {
-          return cb(error)
-        }
-      }
-    } catch (error) {
-      cb(error)
+    // Allow for promises
+    if (result && typeof result.then === 'function') {
+      result.then(res => cb(null, res), cb)
     }
   }
 }

--- a/index.js
+++ b/index.js
@@ -3,6 +3,20 @@
 const fp = require('fastify-plugin')
 const vary = require('./vary')
 
+const defaultOptions = {
+  origin: '*',
+  methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+  preflightContinue: false,
+  optionsSuccessStatus: 204,
+  credentials: false,
+  exposedHeaders: null,
+  allowedHeaders: null,
+  maxAge: null,
+  preflight: true,
+  hideOptionsRoute: true,
+  strictPreflight: true
+}
+
 function fastifyCors (fastify, opts, next) {
   const {
     origin,
@@ -15,19 +29,7 @@ function fastifyCors (fastify, opts, next) {
     preflight,
     hideOptionsRoute,
     strictPreflight
-  } = Object.assign({
-    origin: '*',
-    methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
-    preflightContinue: false,
-    optionsSuccessStatus: 204,
-    credentials: false,
-    exposedHeaders: null,
-    allowedHeaders: null,
-    maxAge: null,
-    preflight: true,
-    hideOptionsRoute: true,
-    strictPreflight: true
-  }, opts)
+  } = Object.assign({}, defaultOptions, opts)
 
   const resolveOriginOption = typeof origin === 'function' ? resolveOriginWrapper : (_, cb) => cb(null, origin)
 

--- a/index.js
+++ b/index.js
@@ -56,11 +56,6 @@ function fastifyCors (fastify, opts, next) {
         return next()
       }
 
-      // Falsy values are invalid
-      if (!resolvedOriginOption) {
-        return next(new Error('Invalid CORS origin option'))
-      }
-
       // Enable preflight
       req.corsOriginAllowed = true
 
@@ -137,7 +132,7 @@ function fastifyCors (fastify, opts, next) {
 }
 
 function getAccessControlAllowOriginHeader (reqOrigin, originOption) {
-  if (originOption === '*') {
+  if (!originOption || originOption === '*') {
     // allow any origin
     return '*'
   }

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function fastifyCors (fastify, opts, next) {
 
   const resolveOriginOption = typeof origin === 'function' ? resolveOriginWrapper : (_, cb) => cb(null, origin)
 
-  fastify.decorateRequest('corsOriginAllowed', undefined)
+  fastify.decorateRequest('corsPreflightEnabled', undefined)
   fastify.addHook('onRequest', onRequest)
 
   if (preflight === true) {
@@ -50,14 +50,12 @@ function fastifyCors (fastify, opts, next) {
         return next(error)
       }
 
+      req.corsPreflightEnabled = resolvedOriginOption
+
       // Disable CORS and preflight if false
       if (resolvedOriginOption === false) {
-        req.corsOriginAllowed = false
         return next()
       }
-
-      // Enable preflight
-      req.corsOriginAllowed = true
 
       reply.header('Access-Control-Allow-Origin',
         getAccessControlAllowOriginHeader(req.headers.origin, resolvedOriginOption))
@@ -79,7 +77,7 @@ function fastifyCors (fastify, opts, next) {
 
   function preflightHandler (req, reply) {
     // Do not handle preflight requests if the origin was not allowed
-    if (!req.corsOriginAllowed) {
+    if (!req.corsPreflightEnabled) {
       reply.code(404).type('text/plain').send('Not Found')
       return
     }

--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ function fastifyCors (fastify, opts, next) {
       .send()
   }
 
-  async function resolveOriginWrapper (req, cb) {
+  function resolveOriginWrapper (req, cb) {
     const result = origin.call(fastify, req.headers.origin, cb)
 
     // Allow for promises

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -170,26 +170,6 @@ test('Dynamic origin resolution (errored)', t => {
   })
 })
 
-test('Dynamic origin resolution (uncaught error)', t => {
-  t.plan(3)
-
-  const fastify = Fastify()
-  const origin = (header, cb) => {
-    t.strictEqual(header, 'example.com')
-    throw new Error('ouch')
-  }
-  fastify.register(cors, { origin })
-
-  fastify.inject({
-    method: 'GET',
-    url: '/',
-    headers: { origin: 'example.com' }
-  }, (err, res) => {
-    t.error(err)
-    t.strictEqual(res.statusCode, 500)
-  })
-})
-
 test('Dynamic origin resolution (invalid result)', t => {
   t.plan(3)
 

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -170,26 +170,6 @@ test('Dynamic origin resolution (errored)', t => {
   })
 })
 
-test('Dynamic origin resolution (invalid result)', t => {
-  t.plan(3)
-
-  const fastify = Fastify()
-  const origin = (header, cb) => {
-    t.strictEqual(header, 'example.com')
-    cb(null, undefined)
-  }
-  fastify.register(cors, { origin })
-
-  fastify.inject({
-    method: 'GET',
-    url: '/',
-    headers: { origin: 'example.com' }
-  }, (err, res) => {
-    t.error(err)
-    t.strictEqual(res.statusCode, 500)
-  })
-})
-
 test('Dynamic origin resolution (valid origin - promises)', t => {
   t.plan(5)
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Refactored implementation for readability.

These important changes were made:
1. I updated the readme to reflect the actual behavior for the value returned when the `origin` option is a function. The docs simply stated it should return `true` or `false` to allow the origin, but the implementation actually use the return value to process to the origin (i.e. it could be a string). This aligns fastify-cors [express-cors](https://github.com/expressjs/cors#configuration-options).
2. If the `origin` option is a function and returns a falsy value other than `false`, for example `undefined`, the hook generates an error. The previous implementation treated this as `*` origin which does not seem intuitive and is not the way that express-cors works.
3. If the `origin` option is a function and throws an error, the error is caught and passed into the hook callback (generating an error).