### PR TITLE
Stricter options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can use it as is without passing any option, or you can configure it as expl
 ### Options
 * `origin`: Configures the **Access-Control-Allow-Origin** CORS header. The value of origin could be of different types:
   - `Boolean` - set `origin` to `true` to reflect the [request origin](http://tools.ietf.org/html/draft-abarth-origin-09), or set it to `false` to disable CORS.
-  - `String` - set `origin` to a specific origin. For example if you set it to `"http://example.com"` only requests from "http://example.com" will be allowed.
+  - `String` - set `origin` to a specific origin. For example if you set it to `"http://example.com"` only requests from "http://example.com" will be allowed. The special `*` value (default) allows any origin.
   - `RegExp` - set `origin` to a regular expression pattern which will be used to test the request origin. If it's a match, the request origin will be reflected. For example the pattern `/example\.com$/` will reflect any request that is coming from an origin ending with "example.com".
   - `Array` - set `origin` to an array of valid origins. Each origin can be a `String` or a `RegExp`. For example `["http://example1.com", /\.example2\.com$/]` will accept any request from "http://example1.com" or from a subdomain of "example2.com".
   - `Function` - set `origin` to a function implementing some custom logic. The function takes the request origin as the first parameter and a callback as a second (which expects the signature `err [Error | null], origin`), where `origin` is a non function value of the origin option. *Async-await* and promises are supported as well. The Fastify instance is bound to function call and you may access via `this`. For example: 

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -170,6 +170,26 @@ test('Dynamic origin resolution (errored)', t => {
   })
 })
 
+test('Dynamic origin resolution (invalid result)', t => {
+  t.plan(3)
+
+  const fastify = Fastify()
+  const origin = (header, cb) => {
+    t.strictEqual(header, 'example.com')
+    cb(null, undefined)
+  }
+  fastify.register(cors, { origin })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: { origin: 'example.com' }
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 500)
+  })
+})
+
 test('Dynamic origin resolution (valid origin - promises)', t => {
   t.plan(5)
 

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -328,6 +328,30 @@ test('Should reply 404 without cors headers other than `vary` when origin is fal
   })
 })
 
+test('Server error if origin option is falsy but not false', t => {
+  t.plan(4)
+
+  const fastify = Fastify()
+  fastify.register(cors, { origin: '' })
+
+  fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: { origin: 'example.com' }
+  }, (err, res) => {
+    t.error(err)
+    delete res.headers.date
+    t.strictEqual(res.statusCode, 500)
+    t.deepEqual(res.json(), { statusCode: 500, error: 'Internal Server Error', message: 'Invalid CORS origin option' })
+    t.deepEqual(res.headers, {
+      'content-length': '89',
+      'content-type': 'application/json; charset=utf-8',
+      connection: 'keep-alive',
+      vary: 'Origin'
+    })
+  })
+})
+
 test('Allow only request from a specific origin', t => {
   t.plan(4)
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This PR makes aligns the implementation with the documentation of the `origin` option:
- any value of the `origin` option or return value of an `origin` function that is falsy **but not** false, results in an error
- a non false falsy value is not defined in the documentation, and will now be considered an error
- this aligns the behavior if `origin` is a value or a function
- before a falsy value of the `origin` option disabled CORS, but a falsy non false return value of an `origin` function set the allowed origin to `*` (any origin)

This is a follow-up PR to #99 . This PR allowed #99 to only refactor and not change functionality.