### PR TITLE
fix: preflight response from hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,28 +52,11 @@ You can use it as is without passing any option, or you can configure it as expl
 * `exposedHeaders`: Configures the **Access-Control-Expose-Headers** CORS header. Expects a comma-delimited string (ex: `'Content-Range,X-Content-Range'`) or an array (ex: `['Content-Range', 'X-Content-Range']`). If not specified, no custom headers are exposed.
 * `credentials`: Configures the **Access-Control-Allow-Credentials** CORS header. Set to `true` to pass the header, otherwise it is omitted.
 * `maxAge`: Configures the **Access-Control-Max-Age** CORS header. In seconds. Set to an integer to pass the header, otherwise it is omitted.
+* `preflightContinue`: Pass the CORS preflight response to the route handler (default: `false`).
 * `optionsSuccessStatus`: Provides a status code to use for successful `OPTIONS` requests, since some legacy browsers (IE11, various SmartTVs) choke on `204`.
 * `preflight`: if needed you can entirely disable preflight by passing `false` here (default: `true`).
 * `strictPreflight`: Enforces strict requirement of the CORS preflight request headers (**Access-Control-Request-Method** and **Origin**) as defined by the [W3C CORS specification](https://www.w3.org/TR/2020/SPSD-cors-20200602/#resource-preflight-requests) (the current [fetch living specification](https://fetch.spec.whatwg.org/) does not define server behavior for missing headers). Preflight requests without the required headers will result in 400 errors when set to `true` (default: `true`).
 * `hideOptionsRoute`: hide options route from the documentation built using [fastify-swagger](https://github.com/fastify/fastify-swagger) (default: `true`).
-
-### Preflight Requests
-
-When preflight is enabled (`preflight` option is `true`), a `*` wildcard `OPTIONS` route is added to the fastify instance. The response behavior can be overridden for individual routes by adding `OPTIONS` routes to the fastify instance (`*` wildcard routes are always lowest priority).
-
-This is an important difference between fastify-cors and the [express cors](https://github.com/expressjs/cors#configuration-options) middleware `preflightContinue` option.
-
-```js
-const fastify = require('fastify')()
-
-// Fastify-cors handles CORS preflight OPTIONS requests
-fastify.register(require('fastify-cors'))
-
-// Except for OPTIONS /not-preflight
-fastify.options('/not-preflight', (req, reply) => {
-  reply.send({hello: 'world'})
-})
-```
 
 ## Acknowledgements
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -44,6 +44,10 @@ export interface FastifyCorsOptions {
      */
     maxAge?: number;
     /**
+     * Pass the CORS preflight response to the route handler (default: false).
+     */
+    preflightContinue?: boolean;
+    /**
      * Provides a status code to use for successful OPTIONS requests,
      * since some legacy browsers (IE11, various SmartTVs) choke on 204.
      */

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function fastifyCors (fastify, opts, next) {
   if (preflight === true) {
     // The preflight reply must occur in the hook. This allows fastify-cors to reply to
     // preflight requests BEFORE possible authentication plugins. If the preflight reply
-    // occurred in the this handler, other plugins may deny the request since the browser will
+    // occurred in this handler, other plugins may deny the request since the browser will
     // remove most headers (such as the Authentication header).
     //
     // This route simply enables fastify to accept preflight requests.

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function fastifyCors (fastify, opts, next) {
     fastify.options('*', { schema: { hide: hideOptionsRoute } }, (req, reply) => {
       if (!req.corsPreflightEnabled) {
         // Do not handle preflight requests if the origin option disabled CORS
-        reply.code(404).type('text/plain').send('Not Found')
+        reply.callNotFound()
         return
       }
 

--- a/index.js
+++ b/index.js
@@ -80,13 +80,13 @@ function fastifyCors (fastify, opts, next) {
       addCorsHeaders(req, reply, resolvedOriginOption)
 
       if (req.raw.method === 'OPTIONS' && preflight === true) {
-        req.corsPreflightEnabled = true
-
         // Strict mode enforces the required headers for preflight
         if (strictPreflight === true && (!req.headers.origin || !req.headers['access-control-request-method'])) {
           reply.status(400).type('text/plain').send('Invalid Preflight Request')
           return
         }
+
+        req.corsPreflightEnabled = true
 
         addPreflightHeaders(req, reply)
 

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -302,10 +302,10 @@ test('Should reply 404 without cors headers other than `vary` when origin is fal
     t.error(err)
     delete res.headers.date
     t.strictEqual(res.statusCode, 404)
-    t.strictEqual(res.payload, 'Not Found')
+    t.strictEqual(res.payload, '{"message":"Route OPTIONS:/ not found","error":"Not Found","statusCode":404}')
     t.deepEqual(res.headers, {
-      'content-length': '9',
-      'content-type': 'text/plain',
+      'content-length': '76',
+      'content-type': 'application/json; charset=utf-8',
       connection: 'keep-alive',
       vary: 'Origin'
     })

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -12,6 +12,7 @@ app.register(fastifyCors, {
   credentials: true,
   exposedHeaders: 'authorization',
   maxAge: 13000,
+  preflightContinue: false,
   optionsSuccessStatus: 200,
   preflight: false,
   strictPreflight: false
@@ -24,6 +25,7 @@ app.register(fastifyCors, {
   credentials: true,
   exposedHeaders: ['authorization'],
   maxAge: 13000,
+  preflightContinue: false,
   optionsSuccessStatus: 200,
   preflight: false,
   strictPreflight: false
@@ -36,6 +38,7 @@ app.register(fastifyCors, {
   credentials: true,
   exposedHeaders: ['authorization'],
   maxAge: 13000,
+  preflightContinue: false,
   optionsSuccessStatus: 200,
   preflight: false,
   strictPreflight: false
@@ -48,6 +51,7 @@ app.register(fastifyCors, {
   credentials: true,
   exposedHeaders: ['authorization'],
   maxAge: 13000,
+  preflightContinue: false,
   optionsSuccessStatus: 200,
   preflight: false,
   strictPreflight: false
@@ -60,6 +64,7 @@ app.register(fastifyCors, {
   credentials: true,
   exposedHeaders: ['authorization'],
   maxAge: 13000,
+  preflightContinue: false,
   optionsSuccessStatus: 200,
   preflight: false,
   strictPreflight: false
@@ -72,6 +77,7 @@ app.register(fastifyCors, {
   credentials: true,
   exposedHeaders: ['authorization'],
   maxAge: 13000,
+  preflightContinue: false,
   optionsSuccessStatus: 200,
   preflight: false,
   strictPreflight: false
@@ -108,6 +114,7 @@ appHttp2.register(fastifyCors, {
   credentials: true,
   exposedHeaders: 'authorization',
   maxAge: 13000,
+  preflightContinue: false,
   optionsSuccessStatus: 200,
   preflight: false,
   strictPreflight: false
@@ -120,6 +127,7 @@ appHttp2.register(fastifyCors, {
   credentials: true,
   exposedHeaders: ['authorization'],
   maxAge: 13000,
+  preflightContinue: false,
   optionsSuccessStatus: 200,
   preflight: false,
   strictPreflight: false
@@ -132,6 +140,7 @@ appHttp2.register(fastifyCors, {
   credentials: true,
   exposedHeaders: ['authorization'],
   maxAge: 13000,
+  preflightContinue: false,
   optionsSuccessStatus: 200,
   preflight: false,
   strictPreflight: false
@@ -144,6 +153,7 @@ appHttp2.register(fastifyCors, {
   credentials: true,
   exposedHeaders: ['authorization'],
   maxAge: 13000,
+  preflightContinue: false,
   optionsSuccessStatus: 200,
   preflight: false,
   strictPreflight: false
@@ -156,6 +166,7 @@ appHttp2.register(fastifyCors, {
   credentials: true,
   exposedHeaders: ['authorization'],
   maxAge: 13000,
+  preflightContinue: false,
   optionsSuccessStatus: 200,
   preflight: false,
   strictPreflight: false
@@ -168,6 +179,7 @@ appHttp2.register(fastifyCors, {
   credentials: true,
   exposedHeaders: ['authorization'],
   maxAge: 13000,
+  preflightContinue: false,
   optionsSuccessStatus: 200,
   preflight: false,
   strictPreflight: false
@@ -186,6 +198,7 @@ appHttp2.register(fastifyCors, {
   credentials: true,
   exposedHeaders: ['authorization'],
   maxAge: 13000,
+  preflightContinue: false,
   optionsSuccessStatus: 200,
   preflight: false,
   strictPreflight: false


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This PR returns the previous functionality removed in #96 . Note that this is not a revert since there were other PRs and changes that still add value to fastify-cors.

As discovered in #102 , replying to preflight requests in a fastify route handler has a big disadvantage: the requests will pass through the request lifecycle and other hooks before the preflight handler executes.

Since the browser removes most header values from a preflight request (including Authentication), the request will most likely be denied by any authentication plugins added to the fastify server.

Therefore, the "best" solution is to reply to preflight requests in the hook and not call the hook callback, ending the request. I documented this in code.

This also brought back the `preflightContinue` option.