### PR TITLE
ci: add `matrix.os` array to test on other os 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
-name: CI workflow
+name: CI
+
 on:
   push:
     paths-ignore:
@@ -8,22 +9,31 @@ on:
     paths-ignore:
       - 'docs/**'
       - '*.md'
+
 jobs:
   test:
     runs-on: ubuntu-latest
+
     strategy:
       matrix:
         node-version: [10.x, 12.x, 13.x, 14.x]
+
     steps:
       - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+
+      - name: Use Node.js
         uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{ matrix.node-version }}
+
       - name: Install Dependencies
-        run: npm install --ignore-scripts
-      - name: Tests
-        run: npm run test:ci
+        run: |
+          npm install --ignore-scripts
+
+      - name: Run Tests
+        run: |
+          npm run test:ci
+
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@v1.1.2
         with:
@@ -45,7 +55,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: fastify/github-action-merge-dependabot@v1.2.1
+      - uses: fastify/github-action-merge-dependabot@v2.0.0
         if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request' }}
         with:
           github-token: ${{secrets.github_token}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,12 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         node-version: [10.x, 12.x, 13.x, 14.x]
+        os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fastify-cors
 
-![CI workflow](https://github.com/fastify/fastify-cors/workflows/CI%20workflow/badge.svg)
+![CI](https://github.com/fastify/fastify-cors/workflows/CI/badge.svg)
 [![NPM version](https://img.shields.io/npm/v/fastify-cors.svg?style=flat)](https://www.npmjs.com/package/fastify-cors)
 [![Known Vulnerabilities](https://snyk.io/test/github/fastify/fastify-cors/badge.svg)](https://snyk.io/test/github/fastify/fastify-cors)
 [![Coverage Status](https://coveralls.io/repos/github/fastify/fastify-cors/badge.svg?branch=master)](https://coveralls.io/github/fastify/fastify-cors?branch=master)


### PR DESCRIPTION
Adds MacOS and Windows OSes to CI testing
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
