### PR TITLE
Fix hideOptionsRoute default behavior

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function fastifyCors (fastify, opts, next) {
   if (typeof opts === 'function') {
     handleCorsOptionsDelegator(opts, fastify)
   } else {
-    hideOptionsRoute = opts.hideOptionsRoute
+    if (opts.hideOptionsRoute !== undefined) hideOptionsRoute = opts.hideOptionsRoute
     const corsOptions = Object.assign({}, defaultOptions, opts)
     fastify.addHook('onRequest', (req, reply, next) => {
       onRequest(fastify, corsOptions, req, reply, next)

--- a/test/preflight.test.js
+++ b/test/preflight.test.js
@@ -183,6 +183,23 @@ test('Should support a prefix for preflight requests', t => {
   })
 })
 
+test('hide options route by default', t => {
+  t.plan(2)
+
+  const fastify = Fastify()
+
+  fastify.addHook('onRoute', (route) => {
+    if (route.method === 'OPTIONS' && route.url === '*') {
+      t.equal(route.schema.hide, true)
+    }
+  })
+  fastify.register(cors)
+
+  fastify.ready(err => {
+    t.error(err)
+  })
+})
+
 test('show options route', t => {
   t.plan(2)
 


### PR DESCRIPTION
If not provided, the `hideOptionsRoute` parameter should be set to `true`, as specified in https://github.com/fastify/fastify-cors/blob/master/README.md

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
