### PR TITLE
Fix 'isRequestOriginAllowed' returns mixed results when regex is used

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,6 +210,7 @@ function isRequestOriginAllowed (reqOrigin, allowedOrigin) {
   } else if (typeof allowedOrigin === 'string') {
     return reqOrigin === allowedOrigin
   } else if (allowedOrigin instanceof RegExp) {
+    allowedOrigin.lastIndex = 0
     return allowedOrigin.test(reqOrigin)
   } else {
     return !!allowedOrigin


### PR DESCRIPTION
Fixes #151

This pull-request contains the code update (Regex.test replaced by String.match function), as well as the update to the tests (The tests now use a global regex, and repeats the test two times to test consistency)

#### Test Output
```
> fastify-cors@6.0.2 test
> npm run lint && npm run unit && npm run typescript


> fastify-cors@6.0.2 lint
> npm run lint:standard && npm run lint:typescript


> fastify-cors@6.0.2 lint:standard
> standard


> fastify-cors@6.0.2 lint:typescript
> standard --parser @typescript-eslint/parser --plugin @typescript-eslint/eslint-plugin test/*.ts


> fastify-cors@6.0.2 unit
> tap test/*.test.js

 PASS  test/vary.test.js 1 OK 6.878ms
 PASS  test/preflight.test.js 51 OK 168.181ms
 PASS  test/cors.test.js 139 OK 236.792ms

                         
  🌈 SUMMARY RESULTS 🌈  
                         

Suites:   3 passed, 3 of 3 completed
Asserts:  191 passed, of 191
Time:     791.297ms
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |     100 |      100 |     100 |     100 |                   
 index.js |     100 |      100 |     100 |     100 |                   
 vary.js  |     100 |      100 |     100 |     100 |                   
----------|---------|----------|---------|---------|-------------------

> fastify-cors@6.0.2 typescript
> tsd
```

#### Checklist
- [ x ] run `npm run test` and ~~`npm run benchmark`~~ -> _Note: There is no 'benchmark' script in package.json_
- [ x ] tests and/or benchmarks are included
- [ x ] documentation is changed or added
- [ x ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
