### PR TITLE
docs: fix origin checking examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ You can use it as is without passing any option or you can configure it as expla
   - `Function` - set `origin` to a function implementing some custom logic. The function takes the request origin as the first parameter and a callback as a second (which expects the signature `err [Error | null], origin`), where `origin` is a non-function value of the origin option. *Async-await* and promises are supported as well. The Fastify instance is bound to function call and you may access via `this`. For example: 
   ```js
   origin: (origin, cb) => {
-    if(/localhost/.test(origin)){
+    const hostname = new URL(origin).hostname
+    if(hostname === "localhost"){
       //  Request from localhost will pass
       cb(null, true)
       return
@@ -74,7 +75,8 @@ fastify.register(require('fastify-cors'), function (instance) {
     let corsOptions;
     const origin = req.headers.origin
     // do not include CORS headers for requests from localhost
-    if (/localhost/.test(origin)) {
+    const hostname = new URL(origin).hostname
+    if(hostname === "localhost"){
       corsOptions = { origin: false }
     } else {
       corsOptions = { origin: true }


### PR DESCRIPTION
Current origin checking in README will pass the request from non-localhost like `https://evil-localhost.test`.
This PR aim to make example code more strict.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
