### PR TITLE
chore: rename hook functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function fastifyCors (fastify, opts, next) {
   } else {
     if (opts.hideOptionsRoute !== undefined) hideOptionsRoute = opts.hideOptionsRoute
     const corsOptions = Object.assign({}, defaultOptions, opts)
-    fastify.addHook('onRequest', (req, reply, next) => {
+    fastify.addHook('onRequest', function onRequestCors (req, reply, next) {
       onRequest(fastify, corsOptions, req, reply, next)
     })
   }
@@ -50,7 +50,7 @@ function fastifyCors (fastify, opts, next) {
 }
 
 function handleCorsOptionsDelegator (optionsResolver, fastify) {
-  fastify.addHook('onRequest', (req, reply, next) => {
+  fastify.addHook('onRequest', function onRequestCors (req, reply, next) {
     if (optionsResolver.length === 2) {
       handleCorsOptionsCallbackDelegator(optionsResolver, fastify, req, reply, next)
       return


### PR DESCRIPTION
I'm starting a new mission: make Fastify's tracing more readable.

Right now, this cors hook is not so nice to see in zipkin (see `anonymous`):

<img width="712" alt="image" src="https://user-images.githubusercontent.com/11404065/167299635-568a52e0-d5a0-4355-9ee8-565042e6ed35.png">

