### PR TITLE
Update readme to mention fastify 4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@
 
 `@fastify/cors` enables the use of [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) in a Fastify application.
 
-Supports Fastify versions `3.x`.
-Please refer to [this branch](https://github.com/fastify/fastify-cors/tree/3.x) and related versions for Fastify `^2.x` compatibility.
-Please refer to [this tag](https://github.com/fastify/fastify-cors/tree/v1.0.0) and related versions for Fastify `^1.x` compatibility.
+Supports Fastify versions `4.x`.
+
+- Please refer to [7.x](https://github.com/fastify/fastify-cors/tree/v7.0.0) for Fastify `^3.x` compatibility.
+- Please refer to [3.x](https://github.com/fastify/fastify-cors/tree/3.x) for Fastify `^2.x` compatibility.
+- Please refer to [1.x](https://github.com/fastify/fastify-cors/tree/v1.0.0) for Fastify `^1.x` compatibility.
 
 ## Install
 ```


### PR DESCRIPTION
I'm trying to use this package with fastify 4.0.2, and it seems like the latest 8.x version supports it.  But, I haven't had any luck yet and maybe the rest of the docs are out of date.  But at least I think this change is accurate.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
