### PR TITLE
expose named export

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,7 +220,15 @@ function isRequestOriginAllowed (reqOrigin, allowedOrigin) {
   }
 }
 
-module.exports = fp(fastifyCors, {
+const _fastifyCors = fp(fastifyCors, {
   fastify: '4.x',
   name: '@fastify/cors'
-})
+});
+
+/**
+ * These export configurations enable JS and TS developers
+ * to consumer fastify in whatever way best suits their needs.
+ */
+module.exports = _fastifyCors;
+module.exports.fastifyCors = _fastifyCors;
+module.exports.default = _fastifyCors;

--- a/index.js
+++ b/index.js
@@ -223,12 +223,12 @@ function isRequestOriginAllowed (reqOrigin, allowedOrigin) {
 const _fastifyCors = fp(fastifyCors, {
   fastify: '4.x',
   name: '@fastify/cors'
-});
+})
 
 /**
  * These export configurations enable JS and TS developers
  * to consumer fastify in whatever way best suits their needs.
  */
-module.exports = _fastifyCors;
-module.exports.fastifyCors = _fastifyCors;
-module.exports.default = _fastifyCors;
+module.exports = _fastifyCors
+module.exports.fastifyCors = _fastifyCors
+module.exports.default = _fastifyCors

--- a/test/named-import.test-d.ts
+++ b/test/named-import.test-d.ts
@@ -1,0 +1,6 @@
+import fastify from 'fastify'
+import { fastifyCors } from '..'
+
+const app = fastify()
+
+app.register(fastifyCors)


### PR DESCRIPTION
#### Checklist

I'm not as ambitious as #224, I'm just trying to make sure `named` exports work for `@fastify/cors`. I'm following what we already did in https://github.com/fastify/fastify

https://github.com/fastify/fastify/blob/acba25acc3e97e3598daf79537a39a5272dba7b8/fastify.js#L783-L796

```js
/**
 * These export configurations enable JS and TS developers
 * to consumer fastify in whatever way best suits their needs.
 * Some examples of supported import syntax includes:
 * - `const fastify = require('fastify')`
 * - `const { fastify } = require('fastify')`
 * - `import * as Fastify from 'fastify'`
 * - `import { fastify, TSC_definition } from 'fastify'`
 * - `import fastify from 'fastify'`
 * - `import fastify, { TSC_definition } from 'fastify'`
 */
module.exports = fastify
module.exports.fastify = fastify
module.exports.default = fastify
```

- [x] run `npm run test` and `npm run lint`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
