### PR TITLE
perf(index): use spread over `Object.assign()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ function handleCorsOptionsCallbackDelegator (optionsResolver, fastify, req, repl
  * @param {import('./types').FastifyCorsOptions} opts
  */
 function normalizeCorsOptions (opts) {
-  const corsOptions = Object.assign({}, defaultOptions, opts)
+  const corsOptions = { ...defaultOptions, ...opts }
   if (Array.isArray(opts.origin) && opts.origin.indexOf('*') !== -1) {
     corsOptions.origin = '*'
   }


### PR DESCRIPTION
Nearly twice as fast, see https://github.com/RafaelGSS/nodejs-bench-operations/blob/main/RESULTS-v18.md#objectassign-vs-spread-operator

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
