### PR TITLE
refactor(vary): use word character inside regex character class

### DIFF
--- a/vary.js
+++ b/vary.js
@@ -20,7 +20,7 @@ const LRUCache = require('mnemonist/lru-cache')
  * @see https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6
  */
 
-const validFieldnameRE = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/
+const validFieldnameRE = /^[!#$%&'*+\-.^\w`|~]+$/u
 function validateFieldname (fieldname) {
   if (validFieldnameRE.test(fieldname) === false) {
     throw new TypeError('Fieldname contains invalid characters.')


### PR DESCRIPTION
- Replaced `a-zA-Z0-9_` inside character class with `\w` word character, [which is equivilent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_expressions/Character_classes)
- Added the `u` unicode flag to every regex pattern, which [acts as a strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/unicode#description) for regex. See https://github.com/fastify/fastify-autoload/pull/330

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
