### PR TITLE
Fix type of OriginCallback

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,7 +2,7 @@
 
 import { FastifyInstance, FastifyPluginCallback, FastifyRequest } from 'fastify';
 
-type OriginCallback = (err: Error | null, allow: boolean) => void;
+type OriginCallback = (err: Error | null, origin: ValueOrArray<OriginType>) => void;
 type OriginType = string | boolean | RegExp;
 type ValueOrArray<T> = T | ArrayOfValueOrArray<T>;
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -117,6 +117,18 @@ app.register(fastifyCors, {
   strictPreflight: false
 })
 
+app.register(fastifyCors, {
+  origin: (origin, cb) => cb(null, true)
+})
+
+app.register(fastifyCors, {
+  origin: (origin, cb) => cb(null, '*')
+})
+
+app.register(fastifyCors, {
+  origin: (origin, cb) => cb(null, /\*/)
+})
+
 const appHttp2 = fastify({ http2: true })
 
 appHttp2.register(fastifyCors)


### PR DESCRIPTION
The documentation for the `OriginCallback` function states:

> Function - set origin to a function implementing some custom logic. The function takes the request origin as the first parameter and a callback as a second (which expects the signature err [Error | null], origin), where origin is a non-function value of the origin option. Async-await and promises are supported as well.

This corrects the type. It is possible that the second parameter should be typed as `ValueOrArray<OriginType> | Promise<ValueOrArray<OriginType>>`. That last sentence is ambiguous and I haven't consulted the implementation.