### PR TITLE
Revert "fix: support for embedded cors for route params (#278)"

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ function fastifyCors (fastify, opts, next) {
   // remove most headers (such as the Authentication header).
   //
   // This route simply enables fastify to accept preflight requests.
-  fastify.options('/*', { schema: { hide: hideOptionsRoute } }, (req, reply) => {
+  fastify.options('*', { schema: { hide: hideOptionsRoute } }, (req, reply) => {
     if (!req.corsPreflightEnabled) {
       // Do not handle preflight requests if the origin option disabled CORS
       reply.callNotFound()

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -354,7 +354,7 @@ test('Should support dynamic config. (Invalid function)', t => {
   t.plan(2)
 
   const fastify = Fastify()
-  fastify.register(cors, () => (a, b, c) => { })
+  fastify.register(cors, () => (a, b, c) => {})
 
   fastify.get('/', (req, reply) => {
     reply.send('ok')
@@ -940,38 +940,5 @@ test('Should support wildcard config /2', t => {
     t.equal(res.statusCode, 200)
     t.equal(res.payload, 'ok')
     t.equal(res.headers['access-control-allow-origin'], '*')
-  })
-})
-
-test('should support embedded cors registration with route params', t => {
-  t.plan(3)
-
-  const fastify = Fastify()
-
-  const custom = async (instance, opts) => {
-    instance.register(cors, {
-      origin: ['example.com']
-    })
-
-    instance.get('/route1', (req, reply) => {
-      reply.send('ok')
-    })
-  }
-
-  fastify.register(custom, {
-    prefix: '/:id'
-  })
-
-  fastify.inject({
-    method: 'OPTIONS',
-    url: '/id1/route1',
-    headers: {
-      'access-control-request-method': 'GET',
-      origin: 'example.com'
-    }
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 204)
-    t.equal(res.headers['access-control-allow-origin'], 'example.com')
   })
 })

--- a/test/preflight.test.js
+++ b/test/preflight.test.js
@@ -360,3 +360,76 @@ test('Can override preflight response with preflightContinue', t => {
     })
   })
 })
+
+test('Should support ongoing prefix ', t => {
+  t.plan(12)
+
+  const fastify = Fastify()
+
+  fastify.register(async (instance) => {
+    instance.register(cors)
+  }, { prefix: '/prefix' })
+
+  // support prefixed route
+  fastify.inject({
+    method: 'OPTIONS',
+    url: '/prefix',
+    headers: {
+      'access-control-request-method': 'GET',
+      origin: 'example.com'
+    }
+  }, (err, res) => {
+    t.error(err)
+    delete res.headers.date
+    t.equal(res.statusCode, 204)
+    t.equal(res.payload, '')
+    t.match(res.headers, {
+      'access-control-allow-origin': '*',
+      'access-control-allow-methods': 'GET,HEAD,PUT,PATCH,POST,DELETE',
+      vary: 'Origin, Access-Control-Request-Headers',
+      'content-length': '0'
+    })
+  })
+
+  // support prefixed route without / continue
+  fastify.inject({
+    method: 'OPTIONS',
+    url: '/prefixfoo',
+    headers: {
+      'access-control-request-method': 'GET',
+      origin: 'example.com'
+    }
+  }, (err, res) => {
+    t.error(err)
+    delete res.headers.date
+    t.equal(res.statusCode, 204)
+    t.equal(res.payload, '')
+    t.match(res.headers, {
+      'access-control-allow-origin': '*',
+      'access-control-allow-methods': 'GET,HEAD,PUT,PATCH,POST,DELETE',
+      vary: 'Origin, Access-Control-Request-Headers',
+      'content-length': '0'
+    })
+  })
+
+  // support prefixed route with / continue
+  fastify.inject({
+    method: 'OPTIONS',
+    url: '/prefix/foo',
+    headers: {
+      'access-control-request-method': 'GET',
+      origin: 'example.com'
+    }
+  }, (err, res) => {
+    t.error(err)
+    delete res.headers.date
+    t.equal(res.statusCode, 204)
+    t.equal(res.payload, '')
+    t.match(res.headers, {
+      'access-control-allow-origin': '*',
+      'access-control-allow-methods': 'GET,HEAD,PUT,PATCH,POST,DELETE',
+      vary: 'Origin, Access-Control-Request-Headers',
+      'content-length': '0'
+    })
+  })
+})

--- a/test/preflight.test.js
+++ b/test/preflight.test.js
@@ -189,7 +189,7 @@ test('hide options route by default', t => {
   const fastify = Fastify()
 
   fastify.addHook('onRoute', (route) => {
-    if (route.method === 'OPTIONS' && route.url === '/*') {
+    if (route.method === 'OPTIONS' && route.url === '*') {
       t.equal(route.schema.hide, true)
     }
   })
@@ -206,7 +206,7 @@ test('show options route', t => {
   const fastify = Fastify()
 
   fastify.addHook('onRoute', (route) => {
-    if (route.method === 'OPTIONS' && route.url === '/*') {
+    if (route.method === 'OPTIONS' && route.url === '*') {
       t.equal(route.schema.hide, false)
     }
   })


### PR DESCRIPTION
Revert #278 
Closes #281 
Closes #282  

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
