### PR TITLE
vary origin on delegated options

### DIFF
--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -124,7 +124,7 @@ test('Should add cors headers (custom values)', t => {
 })
 
 test('Should support dynamic config (callback)', t => {
-  t.plan(18)
+  t.plan(16)
 
   const configs = [{
     origin: 'example.com',
@@ -177,9 +177,9 @@ test('Should support dynamic config (callback)', t => {
       'access-control-allow-origin': 'example.com',
       'access-control-allow-credentials': 'true',
       'access-control-expose-headers': 'foo, bar',
-      'content-length': '2'
+      'content-length': '2',
+      vary: 'Origin'
     })
-    t.notMatch(res.headers, { vary: 'Origin' })
   })
 
   fastify.inject({
@@ -202,9 +202,9 @@ test('Should support dynamic config (callback)', t => {
       'access-control-allow-headers': 'baz, foo',
       'access-control-max-age': '321',
       'cache-control': '456',
-      'content-length': '0'
+      'content-length': '0',
+      vary: 'Origin'
     })
-    t.notMatch(res.headers, { vary: 'Origin' })
   })
 
   fastify.inject({
@@ -221,7 +221,7 @@ test('Should support dynamic config (callback)', t => {
 })
 
 test('Should support dynamic config (Promise)', t => {
-  t.plan(26)
+  t.plan(23)
 
   const configs = [{
     origin: 'example.com',
@@ -282,9 +282,9 @@ test('Should support dynamic config (Promise)', t => {
       'access-control-allow-origin': 'example.com',
       'access-control-allow-credentials': 'true',
       'access-control-expose-headers': 'foo, bar',
-      'content-length': '2'
+      'content-length': '2',
+      vary: 'Origin'
     })
-    t.notMatch(res.headers, { vary: 'Origin' })
   })
 
   fastify.inject({
@@ -306,9 +306,9 @@ test('Should support dynamic config (Promise)', t => {
       'access-control-allow-methods': 'GET',
       'access-control-allow-headers': 'baz, foo',
       'access-control-max-age': '321',
-      'content-length': '0'
+      'content-length': '0',
+      vary: 'Origin'
     })
-    t.notMatch(res.headers, { vary: 'Origin' })
     t.equal(res.headers['cache-control'], undefined, 'cache-control omitted (invalid value)')
   })
 
@@ -332,9 +332,9 @@ test('Should support dynamic config (Promise)', t => {
       'access-control-allow-headers': 'baz, foo',
       'access-control-max-age': '321',
       'cache-control': 'public, max-age=456', // cache-control included (custom string)
-      'content-length': '0'
+      'content-length': '0',
+      vary: 'Origin'
     })
-    t.notMatch(res.headers, { vary: 'Origin' })
   })
 
   fastify.inject({

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -321,7 +321,7 @@ test('Should set hook preSerialization if hook option is set to preSerialization
 })
 
 test('Should support custom hook with dynamic config', t => {
-  t.plan(18)
+  t.plan(16)
 
   const configs = [{
     origin: 'example.com',
@@ -375,9 +375,9 @@ test('Should support custom hook with dynamic config', t => {
       'access-control-allow-origin': 'example.com',
       'access-control-allow-credentials': 'true',
       'access-control-expose-headers': 'foo, bar',
-      'content-length': '2'
+      'content-length': '2',
+      vary: 'Origin'
     })
-    t.notMatch(res.headers, { vary: 'Origin' })
   })
 
   fastify.inject({
@@ -399,9 +399,9 @@ test('Should support custom hook with dynamic config', t => {
       'access-control-allow-methods': 'GET',
       'access-control-allow-headers': 'baz, foo',
       'access-control-max-age': '321',
-      'content-length': '0'
+      'content-length': '0',
+      vary: 'Origin'
     })
-    t.notMatch(res.headers, { vary: 'Origin' })
   })
 
   fastify.inject({
@@ -418,7 +418,7 @@ test('Should support custom hook with dynamic config', t => {
 })
 
 test('Should support custom hook with dynamic config (callback)', t => {
-  t.plan(18)
+  t.plan(16)
 
   const configs = [{
     origin: 'example.com',
@@ -472,9 +472,9 @@ test('Should support custom hook with dynamic config (callback)', t => {
       'access-control-allow-origin': 'example.com',
       'access-control-allow-credentials': 'true',
       'access-control-expose-headers': 'foo, bar',
-      'content-length': '2'
+      'content-length': '2',
+      vary: 'Origin'
     })
-    t.notMatch(res.headers, { vary: 'Origin' })
   })
 
   fastify.inject({
@@ -496,9 +496,9 @@ test('Should support custom hook with dynamic config (callback)', t => {
       'access-control-allow-methods': 'GET',
       'access-control-allow-headers': 'baz, foo',
       'access-control-max-age': '321',
-      'content-length': '0'
+      'content-length': '0',
+      vary: 'Origin'
     })
-    t.notMatch(res.headers, { vary: 'Origin' })
   })
 
   fastify.inject({
@@ -515,7 +515,7 @@ test('Should support custom hook with dynamic config (callback)', t => {
 })
 
 test('Should support custom hook with dynamic config (Promise)', t => {
-  t.plan(18)
+  t.plan(16)
 
   const configs = [{
     origin: 'example.com',
@@ -570,9 +570,9 @@ test('Should support custom hook with dynamic config (Promise)', t => {
       'access-control-allow-origin': 'example.com',
       'access-control-allow-credentials': 'true',
       'access-control-expose-headers': 'foo, bar',
-      'content-length': '2'
+      'content-length': '2',
+      vary: 'Origin'
     })
-    t.notMatch(res.headers, { vary: 'Origin' })
   })
 
   fastify.inject({
@@ -594,9 +594,9 @@ test('Should support custom hook with dynamic config (Promise)', t => {
       'access-control-allow-methods': 'GET',
       'access-control-allow-headers': 'baz, foo',
       'access-control-max-age': '321',
-      'content-length': '0'
+      'content-length': '0',
+      vary: 'Origin'
     })
-    t.notMatch(res.headers, { vary: 'Origin' })
   })
 
   fastify.inject({


### PR DESCRIPTION
When the options used are delegated to a function, then the origin could be dynamic and should add `vary: origin` header.

The symbol usage feels a bit hacky, but the test changes should be ok.

fixes #291

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test`
- [x] tests are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
