### PR TITLE
add AsyncOriginFunction type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -23,6 +23,7 @@ type FastifyCorsHook =
 
 declare namespace fastifyCors {
   export type OriginFunction = (origin: string | undefined, callback: OriginCallback) => void;
+  export type AsyncOriginFunction = (origin: string | undefined) => Promise<ValueOrArray<OriginType>>;
 
   export interface FastifyCorsOptions {
     /**
@@ -38,7 +39,7 @@ declare namespace fastifyCors {
     /**
      * Configures the Access-Control-Allow-Origin CORS header.
      */
-    origin?: ValueOrArray<OriginType> | fastifyCors.OriginFunction;
+    origin?: ValueOrArray<OriginType> | fastifyCors.AsyncOriginFunction | fastifyCors.OriginFunction;
     /**
      * Configures the Access-Control-Allow-Credentials CORS header.
      * Set to true to pass the header, otherwise it is omitted.


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [X] run `npm run test` and ~`npm run benchmark`~
- [X] tests and/or benchmarks are included
- ~[] documentation is changed or added~
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


The JavaScript implementation handles async functions already and also the documentation says that async-functions are supported. Just the types don't reflect that.

> *Async-await* and promises are supported as well. 

[Source](https://github.com/fastify/fastify-cors/blob/master/README.md?plain=1#L53)

```

    // Allow for promises
    if (result && typeof result.then === 'function') {
      result.then(res => cb(null, res), cb)
    }
```
[Source](https://github.com/fastify/fastify-cors/blob/master/index.js#L261)