### PR TITLE
chore: migrate from tap to node:test and c8

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,11 @@
   "type": "commonjs",
   "types": "types/index.d.ts",
   "scripts": {
-    "coverage": "tap --coverage-report=html test",
     "lint": "standard",
     "lint:fix": "standard --fix",
     "test": "npm run test:unit && npm run test:typescript",
     "test:typescript": "tsd",
-    "test:unit": "tap test/*.test.js"
+    "test:unit": "c8 --100 node --test"
   },
   "keywords": [
     "fastify",
@@ -35,10 +34,10 @@
     "@types/node": "^22.0.0",
     "@typescript-eslint/eslint-plugin": "^7.3.1",
     "@typescript-eslint/parser": "^7.3.1",
+    "c8": "^10.1.2",
     "cors": "^2.8.5",
     "fastify": "^5.0.0-alpha.3",
     "standard": "^17.1.0",
-    "tap": "18.7.1",
     "tsd": "^0.31.1",
     "typescript": "^5.4.2"
   },

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -1,15 +1,23 @@
 'use strict'
 
-const { test } = require('tap')
+const { test } = require('node:test')
 const Fastify = require('fastify')
 const kFastifyContext = require('fastify/lib/symbols').kRouteContext
 const cors = require('..')
+const { setTimeout: sleep } = require('node:timers/promises')
 
 test('Should error on invalid hook option', async (t) => {
-  t.plan(1)
+  t.plan(3)
 
   const fastify = Fastify()
-  t.rejects(async () => fastify.register(cors, { hook: 'invalid' }), new TypeError('@fastify/cors: Invalid hook option provided.'))
+  await t.assert.rejects(
+    async () => fastify.register(cors, { hook: 'invalid' }),
+    (err) => {
+      t.assert.strictEqual(err.name, 'TypeError')
+      t.assert.strictEqual(err.message, '@fastify/cors: Invalid hook option provided.')
+      return true
+    }
+  )
 })
 
 test('Should set hook onRequest if hook option is not set', async (t) => {
@@ -20,13 +28,13 @@ test('Should set hook onRequest if hook option is not set', async (t) => {
   fastify.register(cors)
 
   fastify.addHook('onResponse', (request, reply, done) => {
-    t.equal(request[kFastifyContext].onError, null)
-    t.equal(request[kFastifyContext].onRequest.length, 1)
-    t.equal(request[kFastifyContext].onSend, null)
-    t.equal(request[kFastifyContext].preHandler, null)
-    t.equal(request[kFastifyContext].preParsing, null)
-    t.equal(request[kFastifyContext].preSerialization, null)
-    t.equal(request[kFastifyContext].preValidation, null)
+    t.assert.strictEqual(request[kFastifyContext].onError, null)
+    t.assert.strictEqual(request[kFastifyContext].onRequest.length, 1)
+    t.assert.strictEqual(request[kFastifyContext].onSend, null)
+    t.assert.strictEqual(request[kFastifyContext].preHandler, null)
+    t.assert.strictEqual(request[kFastifyContext].preParsing, null)
+    t.assert.strictEqual(request[kFastifyContext].preSerialization, null)
+    t.assert.strictEqual(request[kFastifyContext].preValidation, null)
     done()
   })
 
@@ -41,9 +49,12 @@ test('Should set hook onRequest if hook option is not set', async (t) => {
     url: '/'
   })
   delete res.headers.date
-  t.equal(res.statusCode, 200)
-  t.equal(res.payload, 'ok')
-  t.match(res.headers, {
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.payload, 'ok')
+  const actualHeader = {
+    'access-control-allow-origin': res.headers['access-control-allow-origin']
+  }
+  t.assert.deepStrictEqual(actualHeader, {
     'access-control-allow-origin': '*'
   })
 })
@@ -58,13 +69,13 @@ test('Should set hook onRequest if hook option is set to onRequest', async (t) =
   })
 
   fastify.addHook('onResponse', (request, reply, done) => {
-    t.equal(request[kFastifyContext].onError, null)
-    t.equal(request[kFastifyContext].onRequest.length, 1)
-    t.equal(request[kFastifyContext].onSend, null)
-    t.equal(request[kFastifyContext].preHandler, null)
-    t.equal(request[kFastifyContext].preParsing, null)
-    t.equal(request[kFastifyContext].preSerialization, null)
-    t.equal(request[kFastifyContext].preValidation, null)
+    t.assert.strictEqual(request[kFastifyContext].onError, null)
+    t.assert.strictEqual(request[kFastifyContext].onRequest.length, 1)
+    t.assert.strictEqual(request[kFastifyContext].onSend, null)
+    t.assert.strictEqual(request[kFastifyContext].preHandler, null)
+    t.assert.strictEqual(request[kFastifyContext].preParsing, null)
+    t.assert.strictEqual(request[kFastifyContext].preSerialization, null)
+    t.assert.strictEqual(request[kFastifyContext].preValidation, null)
     done()
   })
 
@@ -79,9 +90,12 @@ test('Should set hook onRequest if hook option is set to onRequest', async (t) =
     url: '/'
   })
   delete res.headers.date
-  t.equal(res.statusCode, 200)
-  t.equal(res.payload, 'ok')
-  t.match(res.headers, {
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.payload, 'ok')
+  const actualHeader = {
+    'access-control-allow-origin': res.headers['access-control-allow-origin']
+  }
+  t.assert.deepStrictEqual(actualHeader, {
     'access-control-allow-origin': '*'
   })
 })
@@ -96,13 +110,13 @@ test('Should set hook preParsing if hook option is set to preParsing', async (t)
   })
 
   fastify.addHook('onResponse', (request, reply, done) => {
-    t.equal(request[kFastifyContext].onError, null)
-    t.equal(request[kFastifyContext].onRequest, null)
-    t.equal(request[kFastifyContext].onSend, null)
-    t.equal(request[kFastifyContext].preHandler, null)
-    t.equal(request[kFastifyContext].preParsing.length, 1)
-    t.equal(request[kFastifyContext].preSerialization, null)
-    t.equal(request[kFastifyContext].preValidation, null)
+    t.assert.strictEqual(request[kFastifyContext].onError, null)
+    t.assert.strictEqual(request[kFastifyContext].onRequest, null)
+    t.assert.strictEqual(request[kFastifyContext].onSend, null)
+    t.assert.strictEqual(request[kFastifyContext].preHandler, null)
+    t.assert.strictEqual(request[kFastifyContext].preParsing.length, 1)
+    t.assert.strictEqual(request[kFastifyContext].preSerialization, null)
+    t.assert.strictEqual(request[kFastifyContext].preValidation, null)
     done()
   })
 
@@ -117,12 +131,15 @@ test('Should set hook preParsing if hook option is set to preParsing', async (t)
     url: '/'
   })
   delete res.headers.date
-  t.equal(res.statusCode, 200)
-  t.equal(res.payload, 'ok')
-  t.match(res.headers, {
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.payload, 'ok')
+  const actualHeader = {
+    'access-control-allow-origin': res.headers['access-control-allow-origin']
+  }
+  t.assert.deepStrictEqual(actualHeader, {
     'access-control-allow-origin': '*'
   })
-  t.notMatch(res.headers, { vary: 'Origin' })
+  t.assert.notStrictEqual(res.headers.vary, 'Origin')
 })
 
 test('Should set hook preValidation if hook option is set to preValidation', async (t) => {
@@ -135,13 +152,13 @@ test('Should set hook preValidation if hook option is set to preValidation', asy
   })
 
   fastify.addHook('onResponse', (request, reply, done) => {
-    t.equal(request[kFastifyContext].onError, null)
-    t.equal(request[kFastifyContext].onRequest, null)
-    t.equal(request[kFastifyContext].onSend, null)
-    t.equal(request[kFastifyContext].preHandler, null)
-    t.equal(request[kFastifyContext].preParsing, null)
-    t.equal(request[kFastifyContext].preSerialization, null)
-    t.equal(request[kFastifyContext].preValidation.length, 1)
+    t.assert.strictEqual(request[kFastifyContext].onError, null)
+    t.assert.strictEqual(request[kFastifyContext].onRequest, null)
+    t.assert.strictEqual(request[kFastifyContext].onSend, null)
+    t.assert.strictEqual(request[kFastifyContext].preHandler, null)
+    t.assert.strictEqual(request[kFastifyContext].preParsing, null)
+    t.assert.strictEqual(request[kFastifyContext].preSerialization, null)
+    t.assert.strictEqual(request[kFastifyContext].preValidation.length, 1)
     done()
   })
 
@@ -156,12 +173,15 @@ test('Should set hook preValidation if hook option is set to preValidation', asy
     url: '/'
   })
   delete res.headers.date
-  t.equal(res.statusCode, 200)
-  t.equal(res.payload, 'ok')
-  t.match(res.headers, {
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.payload, 'ok')
+  const actualHeader = {
+    'access-control-allow-origin': res.headers['access-control-allow-origin']
+  }
+  t.assert.deepStrictEqual(actualHeader, {
     'access-control-allow-origin': '*'
   })
-  t.notMatch(res.headers, { vary: 'Origin' })
+  t.assert.notStrictEqual(res.headers.vary, 'Origin')
 })
 
 test('Should set hook preParsing if hook option is set to preParsing', async (t) => {
@@ -174,13 +194,13 @@ test('Should set hook preParsing if hook option is set to preParsing', async (t)
   })
 
   fastify.addHook('onResponse', (request, reply, done) => {
-    t.equal(request[kFastifyContext].onError, null)
-    t.equal(request[kFastifyContext].onRequest, null)
-    t.equal(request[kFastifyContext].onSend, null)
-    t.equal(request[kFastifyContext].preHandler, null)
-    t.equal(request[kFastifyContext].preParsing.length, 1)
-    t.equal(request[kFastifyContext].preSerialization, null)
-    t.equal(request[kFastifyContext].preValidation, null)
+    t.assert.strictEqual(request[kFastifyContext].onError, null)
+    t.assert.strictEqual(request[kFastifyContext].onRequest, null)
+    t.assert.strictEqual(request[kFastifyContext].onSend, null)
+    t.assert.strictEqual(request[kFastifyContext].preHandler, null)
+    t.assert.strictEqual(request[kFastifyContext].preParsing.length, 1)
+    t.assert.strictEqual(request[kFastifyContext].preSerialization, null)
+    t.assert.strictEqual(request[kFastifyContext].preValidation, null)
     done()
   })
 
@@ -195,12 +215,15 @@ test('Should set hook preParsing if hook option is set to preParsing', async (t)
     url: '/'
   })
   delete res.headers.date
-  t.equal(res.statusCode, 200)
-  t.equal(res.payload, 'ok')
-  t.match(res.headers, {
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.payload, 'ok')
+  const actualHeader = {
+    'access-control-allow-origin': res.headers['access-control-allow-origin']
+  }
+  t.assert.deepStrictEqual(actualHeader, {
     'access-control-allow-origin': '*'
   })
-  t.notMatch(res.headers, { vary: 'Origin' })
+  t.assert.notStrictEqual(res.headers.vary, 'Origin')
 })
 
 test('Should set hook preHandler if hook option is set to preHandler', async (t) => {
@@ -213,13 +236,13 @@ test('Should set hook preHandler if hook option is set to preHandler', async (t)
   })
 
   fastify.addHook('onResponse', (request, reply, done) => {
-    t.equal(request[kFastifyContext].onError, null)
-    t.equal(request[kFastifyContext].onRequest, null)
-    t.equal(request[kFastifyContext].onSend, null)
-    t.equal(request[kFastifyContext].preHandler.length, 1)
-    t.equal(request[kFastifyContext].preParsing, null)
-    t.equal(request[kFastifyContext].preSerialization, null)
-    t.equal(request[kFastifyContext].preValidation, null)
+    t.assert.strictEqual(request[kFastifyContext].onError, null)
+    t.assert.strictEqual(request[kFastifyContext].onRequest, null)
+    t.assert.strictEqual(request[kFastifyContext].onSend, null)
+    t.assert.strictEqual(request[kFastifyContext].preHandler.length, 1)
+    t.assert.strictEqual(request[kFastifyContext].preParsing, null)
+    t.assert.strictEqual(request[kFastifyContext].preSerialization, null)
+    t.assert.strictEqual(request[kFastifyContext].preValidation, null)
     done()
   })
 
@@ -234,12 +257,15 @@ test('Should set hook preHandler if hook option is set to preHandler', async (t)
     url: '/'
   })
   delete res.headers.date
-  t.equal(res.statusCode, 200)
-  t.equal(res.payload, 'ok')
-  t.match(res.headers, {
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.payload, 'ok')
+  const actualHeader = {
+    'access-control-allow-origin': res.headers['access-control-allow-origin']
+  }
+  t.assert.deepStrictEqual(actualHeader, {
     'access-control-allow-origin': '*'
   })
-  t.notMatch(res.headers, { vary: 'Origin' })
+  t.assert.notStrictEqual(res.headers.vary, 'Origin')
 })
 
 test('Should set hook onSend if hook option is set to onSend', async (t) => {
@@ -252,13 +278,13 @@ test('Should set hook onSend if hook option is set to onSend', async (t) => {
   })
 
   fastify.addHook('onResponse', (request, reply, done) => {
-    t.equal(request[kFastifyContext].onError, null)
-    t.equal(request[kFastifyContext].onRequest, null)
-    t.equal(request[kFastifyContext].onSend.length, 1)
-    t.equal(request[kFastifyContext].preHandler, null)
-    t.equal(request[kFastifyContext].preParsing, null)
-    t.equal(request[kFastifyContext].preSerialization, null)
-    t.equal(request[kFastifyContext].preValidation, null)
+    t.assert.strictEqual(request[kFastifyContext].onError, null)
+    t.assert.strictEqual(request[kFastifyContext].onRequest, null)
+    t.assert.strictEqual(request[kFastifyContext].onSend.length, 1)
+    t.assert.strictEqual(request[kFastifyContext].preHandler, null)
+    t.assert.strictEqual(request[kFastifyContext].preParsing, null)
+    t.assert.strictEqual(request[kFastifyContext].preSerialization, null)
+    t.assert.strictEqual(request[kFastifyContext].preValidation, null)
     done()
   })
 
@@ -273,12 +299,15 @@ test('Should set hook onSend if hook option is set to onSend', async (t) => {
     url: '/'
   })
   delete res.headers.date
-  t.equal(res.statusCode, 200)
-  t.equal(res.payload, 'ok')
-  t.match(res.headers, {
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.payload, 'ok')
+  const actualHeader = {
+    'access-control-allow-origin': res.headers['access-control-allow-origin']
+  }
+  t.assert.deepStrictEqual(actualHeader, {
     'access-control-allow-origin': '*'
   })
-  t.notMatch(res.headers, { vary: 'Origin' })
+  t.assert.notStrictEqual(res.headers.vary, 'Origin')
 })
 
 test('Should set hook preSerialization if hook option is set to preSerialization', async (t) => {
@@ -291,13 +320,13 @@ test('Should set hook preSerialization if hook option is set to preSerialization
   })
 
   fastify.addHook('onResponse', (request, reply, done) => {
-    t.equal(request[kFastifyContext].onError, null)
-    t.equal(request[kFastifyContext].onRequest, null)
-    t.equal(request[kFastifyContext].onSend, null)
-    t.equal(request[kFastifyContext].preHandler, null)
-    t.equal(request[kFastifyContext].preParsing, null)
-    t.equal(request[kFastifyContext].preSerialization.length, 1)
-    t.equal(request[kFastifyContext].preValidation, null)
+    t.assert.strictEqual(request[kFastifyContext].onError, null)
+    t.assert.strictEqual(request[kFastifyContext].onRequest, null)
+    t.assert.strictEqual(request[kFastifyContext].onSend, null)
+    t.assert.strictEqual(request[kFastifyContext].preHandler, null)
+    t.assert.strictEqual(request[kFastifyContext].preParsing, null)
+    t.assert.strictEqual(request[kFastifyContext].preSerialization.length, 1)
+    t.assert.strictEqual(request[kFastifyContext].preValidation, null)
     done()
   })
 
@@ -312,15 +341,18 @@ test('Should set hook preSerialization if hook option is set to preSerialization
     url: '/'
   })
   delete res.headers.date
-  t.equal(res.statusCode, 200)
-  t.equal(res.payload, '{"nonString":true}')
-  t.match(res.headers, {
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.payload, '{"nonString":true}')
+  const actualHeader = {
+    'access-control-allow-origin': res.headers['access-control-allow-origin']
+  }
+  t.assert.deepStrictEqual(actualHeader, {
     'access-control-allow-origin': '*'
   })
-  t.notMatch(res.headers, { vary: 'Origin' })
+  t.assert.notStrictEqual(res.headers.vary, 'Origin')
 })
 
-test('Should support custom hook with dynamic config', t => {
+test('Should support custom hook with dynamic config', async t => {
   t.plan(16)
 
   const configs = [{
@@ -341,20 +373,20 @@ test('Should support custom hook with dynamic config', t => {
 
   const fastify = Fastify()
   let requestId = 0
-  const configDelegation = function (req, cb) {
+  const configDelegation = async function (req) {
     // request should have id
-    t.ok(req.id)
+    t.assert.ok(req.id)
     // request should not have send
-    t.notOk(req.send)
+    t.assert.ifError(req.send)
     const config = configs[requestId]
     requestId++
     if (config) {
-      cb(null, config)
+      return Promise.resolve(config)
     } else {
-      cb(new Error('ouch'))
+      return Promise.reject(new Error('ouch'))
     }
   }
-  fastify.register(cors, {
+  await fastify.register(cors, {
     hook: 'preHandler',
     delegator: configDelegation
   })
@@ -363,61 +395,75 @@ test('Should support custom hook with dynamic config', t => {
     reply.send('ok')
   })
 
-  fastify.inject({
+  let res = await fastify.inject({
     method: 'GET',
     url: '/'
-  }, (err, res) => {
-    t.error(err)
-    delete res.headers.date
-    t.equal(res.statusCode, 200)
-    t.equal(res.payload, 'ok')
-    t.match(res.headers, {
-      'access-control-allow-origin': 'example.com',
-      'access-control-allow-credentials': 'true',
-      'access-control-expose-headers': 'foo, bar',
-      'content-length': '2',
-      vary: 'Origin'
-    })
+  })
+  t.assert.ok(res)
+  delete res.headers.date
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.payload, 'ok')
+  let actualHeaders = {
+    'access-control-allow-origin': res.headers['access-control-allow-origin'],
+    'access-control-allow-credentials': res.headers['access-control-allow-credentials'],
+    'access-control-expose-headers': res.headers['access-control-expose-headers'],
+    'content-length': res.headers['content-length'],
+    vary: res.headers.vary
+  }
+  t.assert.deepStrictEqual(actualHeaders, {
+    'access-control-allow-origin': 'example.com',
+    'access-control-allow-credentials': 'true',
+    'access-control-expose-headers': 'foo, bar',
+    'content-length': '2',
+    vary: 'Origin'
   })
 
-  fastify.inject({
+  res = await fastify.inject({
     method: 'OPTIONS',
     url: '/',
     headers: {
       'access-control-request-method': 'GET',
       origin: 'example.com'
     }
-  }, (err, res) => {
-    t.error(err)
-    delete res.headers.date
-    t.equal(res.statusCode, 204)
-    t.equal(res.payload, '')
-    t.match(res.headers, {
-      'access-control-allow-origin': 'sample.com',
-      'access-control-allow-credentials': 'true',
-      'access-control-expose-headers': 'zoo, bar',
-      'access-control-allow-methods': 'GET',
-      'access-control-allow-headers': 'baz, foo',
-      'access-control-max-age': '321',
-      'content-length': '0',
-      vary: 'Origin'
-    })
+  })
+  t.assert.ok(res)
+  delete res.headers.date
+  t.assert.strictEqual(res.statusCode, 204)
+  t.assert.strictEqual(res.payload, '')
+  actualHeaders = {
+    'access-control-allow-origin': res.headers['access-control-allow-origin'],
+    'access-control-allow-credentials': res.headers['access-control-allow-credentials'],
+    'access-control-expose-headers': res.headers['access-control-expose-headers'],
+    'access-control-allow-methods': res.headers['access-control-allow-methods'],
+    'access-control-allow-headers': res.headers['access-control-allow-headers'],
+    'access-control-max-age': res.headers['access-control-max-age'],
+    'content-length': res.headers['content-length'],
+    vary: res.headers.vary
+  }
+  t.assert.deepStrictEqual(actualHeaders, {
+    'access-control-allow-origin': 'sample.com',
+    'access-control-allow-credentials': 'true',
+    'access-control-expose-headers': 'zoo, bar',
+    'access-control-allow-methods': 'GET',
+    'access-control-allow-headers': 'baz, foo',
+    'access-control-max-age': '321',
+    'content-length': '0',
+    vary: 'Origin'
   })
 
-  fastify.inject({
+  res = await fastify.inject({
     method: 'GET',
     url: '/',
     headers: {
       'access-control-request-method': 'GET',
       origin: 'example.com'
     }
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 500)
   })
+  t.assert.ok(res)
+  t.assert.strictEqual(res.statusCode, 500)
 })
 
-test('Should support custom hook with dynamic config (callback)', t => {
+test('Should support custom hook with dynamic config (callback)', async t => {
   t.plan(16)
 
   const configs = [{
@@ -440,9 +486,9 @@ test('Should support custom hook with dynamic config (callback)', t => {
   let requestId = 0
   const configDelegation = function (req, cb) {
     // request should have id
-    t.ok(req.id)
+    t.assert.ok(req.id)
     // request should not have send
-    t.notOk(req.send)
+    t.assert.ifError(req.send)
     const config = configs[requestId]
     requestId++
     if (config) {
@@ -464,11 +510,18 @@ test('Should support custom hook with dynamic config (callback)', t => {
     method: 'GET',
     url: '/'
   }, (err, res) => {
-    t.error(err)
+    t.assert.ifError(err)
     delete res.headers.date
-    t.equal(res.statusCode, 200)
-    t.equal(res.payload, 'ok')
-    t.match(res.headers, {
+    t.assert.strictEqual(res.statusCode, 200)
+    t.assert.strictEqual(res.payload, 'ok')
+    const actualHeaders = {
+      'access-control-allow-origin': res.headers['access-control-allow-origin'],
+      'access-control-allow-credentials': res.headers['access-control-allow-credentials'],
+      'access-control-expose-headers': res.headers['access-control-expose-headers'],
+      'content-length': res.headers['content-length'],
+      vary: res.headers.vary
+    }
+    t.assert.deepStrictEqual(actualHeaders, {
       'access-control-allow-origin': 'example.com',
       'access-control-allow-credentials': 'true',
       'access-control-expose-headers': 'foo, bar',
@@ -485,11 +538,21 @@ test('Should support custom hook with dynamic config (callback)', t => {
       origin: 'example.com'
     }
   }, (err, res) => {
-    t.error(err)
+    t.assert.ifError(err)
     delete res.headers.date
-    t.equal(res.statusCode, 204)
-    t.equal(res.payload, '')
-    t.match(res.headers, {
+    t.assert.strictEqual(res.statusCode, 204)
+    t.assert.strictEqual(res.payload, '')
+    const actualHeaders = {
+      'access-control-allow-origin': res.headers['access-control-allow-origin'],
+      'access-control-allow-credentials': res.headers['access-control-allow-credentials'],
+      'access-control-expose-headers': res.headers['access-control-expose-headers'],
+      'access-control-allow-methods': res.headers['access-control-allow-methods'],
+      'access-control-allow-headers': res.headers['access-control-allow-headers'],
+      'access-control-max-age': res.headers['access-control-max-age'],
+      'content-length': res.headers['content-length'],
+      vary: res.headers.vary
+    }
+    t.assert.deepStrictEqual(actualHeaders, {
       'access-control-allow-origin': 'sample.com',
       'access-control-allow-credentials': 'true',
       'access-control-expose-headers': 'zoo, bar',
@@ -509,12 +572,13 @@ test('Should support custom hook with dynamic config (callback)', t => {
       origin: 'example.com'
     }
   }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 500)
+    t.assert.ifError(err)
+    t.assert.strictEqual(res.statusCode, 500)
   })
+  await sleep()
 })
 
-test('Should support custom hook with dynamic config (Promise)', t => {
+test('Should support custom hook with dynamic config (Promise)', async t => {
   t.plan(16)
 
   const configs = [{
@@ -535,11 +599,11 @@ test('Should support custom hook with dynamic config (Promise)', t => {
 
   const fastify = Fastify()
   let requestId = 0
-  const configDelegation = function (req) {
+  const configDelegation = async function (req) {
     // request should have id
-    t.ok(req.id)
+    t.assert.ok(req.id)
     // request should not have send
-    t.notOk(req.send)
+    t.assert.ifError(req.send)
     const config = configs[requestId]
     requestId++
     if (config) {
@@ -549,7 +613,7 @@ test('Should support custom hook with dynamic config (Promise)', t => {
     }
   }
 
-  fastify.register(cors, {
+  await fastify.register(cors, {
     hook: 'preParsing',
     delegator: configDelegation
   })
@@ -558,61 +622,76 @@ test('Should support custom hook with dynamic config (Promise)', t => {
     reply.send('ok')
   })
 
-  fastify.inject({
+  let res = await fastify.inject({
     method: 'GET',
     url: '/'
-  }, (err, res) => {
-    t.error(err)
-    delete res.headers.date
-    t.equal(res.statusCode, 200)
-    t.equal(res.payload, 'ok')
-    t.match(res.headers, {
-      'access-control-allow-origin': 'example.com',
-      'access-control-allow-credentials': 'true',
-      'access-control-expose-headers': 'foo, bar',
-      'content-length': '2',
-      vary: 'Origin'
-    })
+  })
+  t.assert.ok(res)
+  delete res.headers.date
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.payload, 'ok')
+  let actualHeaders = {
+    'access-control-allow-origin': res.headers['access-control-allow-origin'],
+    'access-control-allow-credentials': res.headers['access-control-allow-credentials'],
+    'access-control-expose-headers': res.headers['access-control-expose-headers'],
+    'content-length': res.headers['content-length'],
+    vary: res.headers.vary
+  }
+
+  t.assert.deepStrictEqual(actualHeaders, {
+    'access-control-allow-origin': 'example.com',
+    'access-control-allow-credentials': 'true',
+    'access-control-expose-headers': 'foo, bar',
+    'content-length': '2',
+    vary: 'Origin'
   })
 
-  fastify.inject({
+  res = await fastify.inject({
     method: 'OPTIONS',
     url: '/',
     headers: {
       'access-control-request-method': 'GET',
       origin: 'example.com'
     }
-  }, (err, res) => {
-    t.error(err)
-    delete res.headers.date
-    t.equal(res.statusCode, 204)
-    t.equal(res.payload, '')
-    t.match(res.headers, {
-      'access-control-allow-origin': 'sample.com',
-      'access-control-allow-credentials': 'true',
-      'access-control-expose-headers': 'zoo, bar',
-      'access-control-allow-methods': 'GET',
-      'access-control-allow-headers': 'baz, foo',
-      'access-control-max-age': '321',
-      'content-length': '0',
-      vary: 'Origin'
-    })
+  })
+  t.assert.ok(res)
+  delete res.headers.date
+  t.assert.strictEqual(res.statusCode, 204)
+  t.assert.strictEqual(res.payload, '')
+  actualHeaders = {
+    'access-control-allow-origin': res.headers['access-control-allow-origin'],
+    'access-control-allow-credentials': res.headers['access-control-allow-credentials'],
+    'access-control-expose-headers': res.headers['access-control-expose-headers'],
+    'access-control-allow-methods': res.headers['access-control-allow-methods'],
+    'access-control-allow-headers': res.headers['access-control-allow-headers'],
+    'access-control-max-age': res.headers['access-control-max-age'],
+    'content-length': res.headers['content-length'],
+    vary: res.headers.vary
+  }
+  t.assert.deepStrictEqual(actualHeaders, {
+    'access-control-allow-origin': 'sample.com',
+    'access-control-allow-credentials': 'true',
+    'access-control-expose-headers': 'zoo, bar',
+    'access-control-allow-methods': 'GET',
+    'access-control-allow-headers': 'baz, foo',
+    'access-control-max-age': '321',
+    'content-length': '0',
+    vary: 'Origin'
   })
 
-  fastify.inject({
+  res = await fastify.inject({
     method: 'GET',
     url: '/',
     headers: {
       'access-control-request-method': 'GET',
       origin: 'example.com'
     }
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 500)
   })
+  t.assert.ok(res)
+  t.assert.strictEqual(res.statusCode, 500)
 })
 
-test('Should support custom hook with dynamic config (Promise), but should error /1', t => {
+test('Should support custom hook with dynamic config (Promise), but should error /1', async t => {
   t.plan(6)
 
   const fastify = Fastify()
@@ -620,7 +699,7 @@ test('Should support custom hook with dynamic config (Promise), but should error
     return false
   }
 
-  fastify.register(cors, {
+  await fastify.register(cors, {
     hook: 'preParsing',
     delegator: configDelegation
   })
@@ -629,37 +708,38 @@ test('Should support custom hook with dynamic config (Promise), but should error
     reply.send('ok')
   })
 
-  fastify.inject({
+  let res = await fastify.inject({
     method: 'OPTIONS',
     url: '/',
     headers: {
       'access-control-request-method': 'GET',
       origin: 'example.com'
     }
-  }, (err, res) => {
-    t.error(err)
-    delete res.headers.date
-    t.equal(res.statusCode, 500)
-    t.equal(res.payload, '{"statusCode":500,"error":"Internal Server Error","message":"Invalid CORS origin option"}')
-    t.match(res.headers, {
-      'content-length': '89'
-    })
+  })
+  t.assert.ok(res)
+  delete res.headers.date
+  t.assert.strictEqual(res.statusCode, 500)
+  t.assert.strictEqual(res.payload, '{"statusCode":500,"error":"Internal Server Error","message":"Invalid CORS origin option"}')
+  const actualHeaders = {
+    'content-length': res.headers['content-length']
+  }
+  t.assert.deepStrictEqual(actualHeaders, {
+    'content-length': '89'
   })
 
-  fastify.inject({
+  res = await fastify.inject({
     method: 'GET',
     url: '/',
     headers: {
       'access-control-request-method': 'GET',
       origin: 'example.com'
     }
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 500)
   })
+  t.assert.ok(res)
+  t.assert.strictEqual(res.statusCode, 500)
 })
 
-test('Should support custom hook with dynamic config (Promise), but should error /2', t => {
+test('Should support custom hook with dynamic config (Promise), but should error /2', async t => {
   t.plan(6)
 
   const fastify = Fastify()
@@ -667,7 +747,7 @@ test('Should support custom hook with dynamic config (Promise), but should error
     return false
   }
 
-  fastify.register(cors, {
+  await fastify.register(cors, {
     delegator: configDelegation
   })
 
@@ -675,32 +755,33 @@ test('Should support custom hook with dynamic config (Promise), but should error
     reply.send('ok')
   })
 
-  fastify.inject({
+  let res = await fastify.inject({
     method: 'OPTIONS',
     url: '/',
     headers: {
       'access-control-request-method': 'GET',
       origin: 'example.com'
     }
-  }, (err, res) => {
-    t.error(err)
-    delete res.headers.date
-    t.equal(res.statusCode, 500)
-    t.equal(res.payload, '{"statusCode":500,"error":"Internal Server Error","message":"Invalid CORS origin option"}')
-    t.match(res.headers, {
-      'content-length': '89'
-    })
+  })
+  t.assert.ok(res)
+  delete res.headers.date
+  t.assert.strictEqual(res.statusCode, 500)
+  t.assert.strictEqual(res.payload, '{"statusCode":500,"error":"Internal Server Error","message":"Invalid CORS origin option"}')
+  const actualHeaders = {
+    'content-length': res.headers['content-length']
+  }
+  t.assert.deepStrictEqual(actualHeaders, {
+    'content-length': '89'
   })
 
-  fastify.inject({
+  res = await fastify.inject({
     method: 'GET',
     url: '/',
     headers: {
       'access-control-request-method': 'GET',
       origin: 'example.com'
     }
-  }, (err, res) => {
-    t.error(err)
-    t.equal(res.statusCode, 500)
   })
+  t.assert.ok(res)
+  t.assert.strictEqual(res.statusCode, 500)
 })

--- a/test/vary.test.js
+++ b/test/vary.test.js
@@ -1,10 +1,10 @@
 'use strict'
 
-const test = require('tap').test
+const { test } = require('node:test')
 const createAddFieldnameToVary = require('../vary').createAddFieldnameToVary
 const parse = require('../vary').parse
 
-test('Should set * even if we set a specific field', t => {
+test('Should set * even if we set a specific field', async t => {
   t.plan(1)
 
   const addOriginToVary = createAddFieldnameToVary('Origin')
@@ -18,7 +18,7 @@ test('Should set * even if we set a specific field', t => {
   }
 
   addOriginToVary(replyMock)
-  t.pass()
+  t.assert.ok(true) // equalivant to tap t.pass()
 })
 
 test('Should set * even if we set a specific field', t => {
@@ -30,8 +30,8 @@ test('Should set * even if we set a specific field', t => {
       return 'Origin'
     },
     header (name, value) {
-      t.same(name, 'Vary')
-      t.same(value, '*')
+      t.assert.deepStrictEqual(name, 'Vary')
+      t.assert.deepStrictEqual(value, '*')
     }
   }
 
@@ -47,13 +47,13 @@ test('Should set * when field contains a *', t => {
       return ['Origin', '*', 'Access-Control-Request-Headers']
     },
     header (name, value) {
-      t.same(name, 'Vary')
-      t.same(value, '*')
+      t.assert.deepStrictEqual(name, 'Vary')
+      t.assert.deepStrictEqual(value, '*')
     }
   }
 
   addOriginToVary(replyMock)
-  t.pass()
+  t.assert.ok(true) // equalivant to tap t.pass()
 })
 
 test('Should concat vary values', t => {
@@ -65,13 +65,13 @@ test('Should concat vary values', t => {
       return 'Access-Control-Request-Headers'
     },
     header (name, value) {
-      t.same(name, 'Vary')
-      t.same(value, 'Access-Control-Request-Headers, Origin')
+      t.assert.deepStrictEqual(name, 'Vary')
+      t.assert.deepStrictEqual(value, 'Access-Control-Request-Headers, Origin')
     }
   }
 
   addOriginToVary(replyMock)
-  t.pass()
+  t.assert.ok(true) // equalivant to tap t.pass()
 })
 
 test('Should concat vary values ignoring consecutive commas', t => {
@@ -83,13 +83,13 @@ test('Should concat vary values ignoring consecutive commas', t => {
       return ' Access-Control-Request-Headers,Access-Control-Request-Method'
     },
     header (name, value) {
-      t.same(name, 'Vary')
-      t.same(value, ' Access-Control-Request-Headers,Access-Control-Request-Method, Origin')
+      t.assert.deepStrictEqual(name, 'Vary')
+      t.assert.deepStrictEqual(value, ' Access-Control-Request-Headers,Access-Control-Request-Method, Origin')
     }
   }
 
   addOriginToVary(replyMock)
-  t.pass()
+  t.assert.ok(true) // equalivant to tap t.pass()
 })
 
 test('Should concat vary values ignoring whitespace', t => {
@@ -101,13 +101,13 @@ test('Should concat vary values ignoring whitespace', t => {
       return ' Access-Control-Request-Headers ,Access-Control-Request-Method'
     },
     header (name, value) {
-      t.same(name, 'Vary')
-      t.same(value, ' Access-Control-Request-Headers ,Access-Control-Request-Method, Origin')
+      t.assert.deepStrictEqual(name, 'Vary')
+      t.assert.deepStrictEqual(value, ' Access-Control-Request-Headers ,Access-Control-Request-Method, Origin')
     }
   }
 
   addOriginToVary(replyMock)
-  t.pass()
+  t.assert.ok(true) // equalivant to tap t.pass()
 })
 
 test('Should set the field as value for vary if no vary is defined', t => {
@@ -119,8 +119,8 @@ test('Should set the field as value for vary if no vary is defined', t => {
       return undefined
     },
     header (name, value) {
-      t.same(name, 'Vary')
-      t.same(value, 'Origin')
+      t.assert.deepStrictEqual(name, 'Vary')
+      t.assert.deepStrictEqual(value, 'Origin')
     }
   }
 
@@ -136,8 +136,8 @@ test('Should set * as value for vary if vary contains *', t => {
       return 'Accept,*'
     },
     header (name, value) {
-      t.same(name, 'Vary')
-      t.same(value, '*')
+      t.assert.deepStrictEqual(name, 'Vary')
+      t.assert.deepStrictEqual(value, '*')
     }
   }
 
@@ -153,8 +153,8 @@ test('Should set Accept-Encoding as value for vary if vary is empty string', t =
       return ''
     },
     header (name, value) {
-      t.same(name, 'Vary')
-      t.same(value, 'Accept-Encoding')
+      t.assert.deepStrictEqual(name, 'Vary')
+      t.assert.deepStrictEqual(value, 'Accept-Encoding')
     }
   }
 
@@ -171,8 +171,8 @@ test('Should have no issues with values containing dashes', t => {
       return this.value
     },
     header (name, value) {
-      t.same(name, 'Vary')
-      t.same(value, 'Accept-Encoding, X-Foo')
+      t.assert.deepStrictEqual(name, 'Vary')
+      t.assert.deepStrictEqual(value, 'Accept-Encoding, X-Foo')
       this.value = value
     }
   }
@@ -195,35 +195,43 @@ test('Should ignore the header as value for vary if it is already in vary', t =>
   }
   addOriginToVary(replyMock)
   addOriginToVary(replyMock)
-  t.pass()
+
+  t.assert.ok(true) // equalivant to tap t.pass()
 })
 
 test('parse', t => {
   t.plan(18)
-  t.same(parse(''), [])
-  t.same(parse('a'), ['a'])
-  t.same(parse('a,b'), ['a', 'b'])
-  t.same(parse('  a,b'), ['a', 'b'])
-  t.same(parse('a,b  '), ['a', 'b'])
-  t.same(parse('a,b,c'), ['a', 'b', 'c'])
-  t.same(parse('A,b,c'), ['a', 'b', 'c'])
-  t.same(parse('a,b,c,'), ['a', 'b', 'c'])
-  t.same(parse('a,b,c, '), ['a', 'b', 'c'])
-  t.same(parse(',a,b,c'), ['a', 'b', 'c'])
-  t.same(parse(' ,a,b,c'), ['a', 'b', 'c'])
-  t.same(parse('a,,b,c'), ['a', 'b', 'c'])
-  t.same(parse('a,,,b,,c'), ['a', 'b', 'c'])
-  t.same(parse('a, b,c'), ['a', 'b', 'c'])
-  t.same(parse('a,   b,c'), ['a', 'b', 'c'])
-  t.same(parse('a, , b,c'), ['a', 'b', 'c'])
-  t.same(parse('a,  , b,c'), ['a', 'b', 'c'])
+  t.assert.deepStrictEqual(parse(''), [])
+  t.assert.deepStrictEqual(parse('a'), ['a'])
+  t.assert.deepStrictEqual(parse('a,b'), ['a', 'b'])
+  t.assert.deepStrictEqual(parse('  a,b'), ['a', 'b'])
+  t.assert.deepStrictEqual(parse('a,b  '), ['a', 'b'])
+  t.assert.deepStrictEqual(parse('a,b,c'), ['a', 'b', 'c'])
+  t.assert.deepStrictEqual(parse('A,b,c'), ['a', 'b', 'c'])
+  t.assert.deepStrictEqual(parse('a,b,c,'), ['a', 'b', 'c'])
+  t.assert.deepStrictEqual(parse('a,b,c, '), ['a', 'b', 'c'])
+  t.assert.deepStrictEqual(parse(',a,b,c'), ['a', 'b', 'c'])
+  t.assert.deepStrictEqual(parse(' ,a,b,c'), ['a', 'b', 'c'])
+  t.assert.deepStrictEqual(parse('a,,b,c'), ['a', 'b', 'c'])
+  t.assert.deepStrictEqual(parse('a,,,b,,c'), ['a', 'b', 'c'])
+  t.assert.deepStrictEqual(parse('a, b,c'), ['a', 'b', 'c'])
+  t.assert.deepStrictEqual(parse('a,   b,c'), ['a', 'b', 'c'])
+  t.assert.deepStrictEqual(parse('a, , b,c'), ['a', 'b', 'c'])
+  t.assert.deepStrictEqual(parse('a,  , b,c'), ['a', 'b', 'c'])
 
   // one for the cache
-  t.same(parse('A,b,c'), ['a', 'b', 'c'])
+  t.assert.deepStrictEqual(parse('A,b,c'), ['a', 'b', 'c'])
 })
 
-test('createAddFieldnameToVary', t => {
-  t.plan(2)
-  t.same(typeof createAddFieldnameToVary('valid-header'), 'function')
-  t.throws(() => createAddFieldnameToVary('invalid:header'), TypeError, 'Field contains invalid characters.')
+test('createAddFieldnameToVary', async t => {
+  t.plan(4)
+  t.assert.strictEqual(typeof createAddFieldnameToVary('valid-header'), 'function')
+  await t.assert.rejects(
+    async () => createAddFieldnameToVary('invalid:header'),
+    (err) => {
+      t.assert.strictEqual(err.name, 'TypeError')
+      t.assert.strictEqual(err.message, 'Fieldname contains invalid characters.')
+      return true
+    }
+  )
 })


### PR DESCRIPTION
#### Checklist

This PR migrates from `tap` to `node:test` and `c8`

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
