### PR TITLE
feat(index): allow cors to be disabled at route level

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,26 @@ fastify.register(async function (fastify) {
 fastify.listen({ port: 3000 })
 ```
 
+### Disabling CORS for a specific route
+
+CORS can be disabled at the route level by setting the `cors` option to `false`.
+
+```js
+const fastify = require('fastify')()
+
+fastify.register(require('@fastify/cors'), { origin: '*' })
+
+fastify.get('/cors-enabled', (_req, reply) => {
+  reply.send('CORS headers')
+})
+
+fastify.get('/cors-disabled', { cors: false }, (_req, reply) => {
+  reply.send('No CORS headers')
+})
+
+fastify.listen({ port: 3000 })
+```
+
 ### Custom Fastify hook name
 
 By default, `@fastify/cors` adds a `onRequest` hook where the validation and header injection are executed. This can be customized by passing `hook` in the options. Valid values are `onRequest`, `preParsing`, `preValidation`, `preHandler`, `preSerialization`, and `onSend`.

--- a/index.js
+++ b/index.js
@@ -171,6 +171,11 @@ function addCorsHeadersHandler (fastify, options, req, reply, next) {
       return next()
     }
 
+    // Allow routes to disable CORS individually
+    if (req.routeOptions.config?.cors === false) {
+      return next()
+    }
+
     // Falsy values are invalid
     if (!resolvedOriginOption) {
       return next(new Error('Invalid CORS origin option'))

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -1015,3 +1015,38 @@ test('Should support wildcard config /2', async t => {
   t.assert.strictEqual(res.payload, 'ok')
   t.assert.strictEqual(res.headers['access-control-allow-origin'], '*')
 })
+
+test('Should allow routes to disable CORS individually', async t => {
+  t.plan(6)
+
+  const fastify = Fastify()
+  fastify.register(cors, { origin: '*' })
+
+  fastify.get('/cors-enabled', (_req, reply) => {
+    reply.send('ok')
+  })
+
+  fastify.get('/cors-disabled', { config: { cors: false } }, (_req, reply) => {
+    reply.send('ok')
+  })
+
+  // Test CORS enabled route
+  let res = await fastify.inject({
+    method: 'GET',
+    url: '/cors-enabled',
+    headers: { origin: 'example.com' }
+  })
+  t.assert.ok(res)
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.headers['access-control-allow-origin'], '*')
+
+  // Test CORS disabled route
+  res = await fastify.inject({
+    method: 'GET',
+    url: '/cors-disabled',
+    headers: { origin: 'example.com' }
+  })
+  t.assert.ok(res)
+  t.assert.strictEqual(res.statusCode, 200)
+  t.assert.strictEqual(res.headers['access-control-allow-origin'], undefined)
+})


### PR DESCRIPTION
I'm submitting this as a Draft PR to gather feedback on my approach.
I'm trying to allow routes to individually enable or disable CORS.
My team finds this useful for creating an API where not all routes
are desirable to be called from a browser. 

My proposal is to allow a configuration option,  `cors: boolean`.

Example usage:

```typescript
  fastify.get<{  }, { cors: boolean }>(
    '/v1/foo/bar',
    {
      config: {
        cors: false,
      },
    },
```


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
