### PR TITLE
build(deps-dev): replace standard with neostandard

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![CI](https://github.com/fastify/fastify-cors/workflows/CI/badge.svg)
 [![NPM version](https://img.shields.io/npm/v/@fastify/cors.svg?style=flat)](https://www.npmjs.com/package/@fastify/cors)
-[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](https://standardjs.com/)
+[![neostandard javascript style](https://img.shields.io/badge/code_style-neostandard-brightgreen?style=flat)](https://github.com/neostandard/neostandard)
 
 
 `@fastify/cors` enables the use of [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) in a Fastify application.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,6 @@
+'use strict'
+
+module.exports = require('neostandard')({
+  ignores: require('neostandard').resolveIgnoresFromGitignore(),
+  ts: true
+})

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "type": "commonjs",
   "types": "types/index.d.ts",
   "scripts": {
-    "lint": "standard",
-    "lint:fix": "standard --fix",
+    "lint": "eslint",
+    "lint:fix": "eslint --fix",
     "test": "npm run test:unit && npm run test:typescript",
     "test:typescript": "tsd",
     "test:unit": "c8 --100 node --test"
@@ -32,12 +32,10 @@
   "devDependencies": {
     "@fastify/pre-commit": "^2.1.0",
     "@types/node": "^22.0.0",
-    "@typescript-eslint/eslint-plugin": "^7.3.1",
-    "@typescript-eslint/parser": "^7.3.1",
     "c8": "^10.1.2",
     "cors": "^2.8.5",
     "fastify": "^5.0.0",
-    "standard": "^17.1.0",
+    "neostandard": "^0.11.9",
     "tsd": "^0.31.1",
     "typescript": "~5.7.2"
   },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,17 +1,17 @@
 /// <reference types="node" />
 
-import { FastifyInstance, FastifyPluginCallback, FastifyRequest } from 'fastify';
+import { FastifyInstance, FastifyPluginCallback, FastifyRequest } from 'fastify'
 
-type OriginCallback = (err: Error | null, origin: ValueOrArray<OriginType>) => void;
-type OriginType = string | boolean | RegExp;
-type ValueOrArray<T> = T | ArrayOfValueOrArray<T>;
+type OriginCallback = (err: Error | null, origin: ValueOrArray<OriginType>) => void
+type OriginType = string | boolean | RegExp
+type ValueOrArray<T> = T | ArrayOfValueOrArray<T>
 
 interface ArrayOfValueOrArray<T> extends Array<ValueOrArray<T>> {
 }
 
 type FastifyCorsPlugin = FastifyPluginCallback<
   NonNullable<fastifyCors.FastifyCorsOptions> | fastifyCors.FastifyCorsOptionsDelegate
->;
+>
 
 type FastifyCorsHook =
   | 'onRequest'
@@ -22,8 +22,8 @@ type FastifyCorsHook =
   | 'onSend'
 
 declare namespace fastifyCors {
-  export type OriginFunction = (origin: string | undefined, callback: OriginCallback) => void;
-  export type AsyncOriginFunction = (origin: string | undefined) => Promise<ValueOrArray<OriginType>>;
+  export type OriginFunction = (origin: string | undefined, callback: OriginCallback) => void
+  export type AsyncOriginFunction = (origin: string | undefined) => Promise<ValueOrArray<OriginType>>
 
   export interface FastifyCorsOptions {
     /**
@@ -102,16 +102,16 @@ declare namespace fastifyCors {
   }
 
   export interface FastifyCorsOptionsDelegateCallback { (req: FastifyRequest, cb: (error: Error | null, corsOptions?: FastifyCorsOptions) => void): void }
-  export interface FastifyCorsOptionsDelegatePromise { (req: FastifyRequest):  Promise<FastifyCorsOptions> }
+  export interface FastifyCorsOptionsDelegatePromise { (req: FastifyRequest): Promise<FastifyCorsOptions> }
   export type FastifyCorsOptionsDelegate = FastifyCorsOptionsDelegateCallback | FastifyCorsOptionsDelegatePromise
-  export type FastifyPluginOptionsDelegate<T = FastifyCorsOptionsDelegate> = (instance: FastifyInstance) => T;
+  export type FastifyPluginOptionsDelegate<T = FastifyCorsOptionsDelegate> = (instance: FastifyInstance) => T
 
   export const fastifyCors: FastifyCorsPlugin
-  export { fastifyCors as default };
+  export { fastifyCors as default }
 }
 
-declare function fastifyCors(
+declare function fastifyCors (
   ...params: Parameters<FastifyCorsPlugin>
-): ReturnType<FastifyCorsPlugin>;
+): ReturnType<FastifyCorsPlugin>
 
-export = fastifyCors;
+export = fastifyCors

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -120,9 +120,9 @@ app.register(fastifyCors, {
 
 const asyncCorsDelegate: OriginFunction = async (origin) => {
   if (origin === undefined || /localhost/.test(origin)) {
-    return true;
+    return true
   }
-  return false;
+  return false
 }
 
 app.register(fastifyCors, {
@@ -371,15 +371,15 @@ appHttp2.register(fastifyCors, delegate)
 appHttp2.register(fastifyCors, {
   hook: 'preParsing',
   origin: function (origin, cb) {
-    expectType<string|undefined>(origin)
+    expectType<string | undefined>(origin)
     cb(null, false)
   },
 })
 
-const asyncOriginFn: AsyncOriginFunction = async function (origin): Promise<boolean>  {
-  expectType<string|undefined>(origin)
-  return false;
-};
+const asyncOriginFn: AsyncOriginFunction = async function (origin): Promise<boolean> {
+  expectType<string | undefined>(origin)
+  return false
+}
 
 appHttp2.register(fastifyCors, {
   hook: 'preParsing',


### PR DESCRIPTION
The main fastify repo migrated from standard to neostandard with https://github.com/fastify/fastify/pull/5509, so the rest of the repos should (neo)standardise around this and use the same linting tool. At present we have a mishmash of standard, eslint with custom rules and various plugins, and prettier across the plugin repos.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
