### PR TITLE
refactor(index): change default `methods` to cors-safelisted methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can use it as is without passing any option or you can configure it as expla
     cb(new Error("Not allowed"), false)
   }
   ```
-* `methods`: Configures the **Access-Control-Allow-Methods** CORS header. Expects a comma-delimited string (e.g., 'GET,PUT,POST') or an array (e.g., `['GET', 'PUT', 'POST']`). Default: `GET,HEAD,PUT,PATCH,POST,DELETE`.
+* `methods`: Configures the **Access-Control-Allow-Methods** CORS header. Expects a comma-delimited string (e.g., 'GET,PUT,POST') or an array (e.g., `['GET', 'PUT', 'POST']`). Default: `GET,HEAD,PUT`.
 * `hook`: See [Custom Fastify hook name](#custom-fastify-hook-name). Default: `onRequest`.
 * `allowedHeaders`: Configures the **Access-Control-Allow-Headers** CORS header. Expects a comma-delimited string (e.g., `'Content-Type,Authorization'`) or an array (e.g., `['Content-Type', 'Authorization']`). Defaults to reflecting the headers specified in the request's **Access-Control-Request-Headers** header if not specified.
 * `exposedHeaders`: Configures the **Access-Control-Expose-Headers** CORS header. Expects a comma-delimited string (e.g., `'Content-Range,X-Content-Range'`) or an array (e.g., `['Content-Range', 'X-Content-Range']`). No custom headers are exposed if not specified.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can use it as is without passing any option or you can configure it as expla
     cb(new Error("Not allowed"), false)
   }
   ```
-* `methods`: Configures the **Access-Control-Allow-Methods** CORS header. Expects a comma-delimited string (e.g., 'GET,PUT,POST') or an array (e.g., `['GET', 'PUT', 'POST']`). Default: `GET,HEAD,PUT`.
+* `methods`: Configures the **Access-Control-Allow-Methods** CORS header. Expects a comma-delimited string (e.g., 'GET,PUT,POST') or an array (e.g., `['GET', 'PUT', 'POST']`). Default: [CORS-safelisted methods](https://fetch.spec.whatwg.org/#methods) `GET,HEAD,PUT`.
 * `hook`: See [Custom Fastify hook name](#custom-fastify-hook-name). Default: `onRequest`.
 * `allowedHeaders`: Configures the **Access-Control-Allow-Headers** CORS header. Expects a comma-delimited string (e.g., `'Content-Type,Authorization'`) or an array (e.g., `['Content-Type', 'Authorization']`). Defaults to reflecting the headers specified in the request's **Access-Control-Request-Headers** header if not specified.
 * `exposedHeaders`: Configures the **Access-Control-Expose-Headers** CORS header. Expects a comma-delimited string (e.g., `'Content-Range,X-Content-Range'`) or an array (e.g., `['Content-Range', 'X-Content-Range']`). No custom headers are exposed if not specified.

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const {
 
 const defaultOptions = {
   origin: '*',
-  methods: 'GET,HEAD,PUT',
+  methods: 'GET,HEAD,POST',
   hook: 'onRequest',
   preflightContinue: false,
   optionsSuccessStatus: 204,

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const {
 
 const defaultOptions = {
   origin: '*',
-  methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+  methods: 'GET,HEAD,PUT',
   hook: 'onRequest',
   preflightContinue: false,
   optionsSuccessStatus: 204,

--- a/test/preflight.test.js
+++ b/test/preflight.test.js
@@ -30,7 +30,7 @@ test('Should reply to preflight requests', async t => {
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT,PATCH,POST,DELETE',
+    'access-control-allow-methods': 'GET,HEAD,PUT',
     vary: 'Access-Control-Request-Headers',
     'content-length': '0'
   })
@@ -65,7 +65,7 @@ test('Should add access-control-allow-headers to response if preflight req has a
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT,PATCH,POST,DELETE',
+    'access-control-allow-methods': 'GET,HEAD,PUT',
     'access-control-allow-headers': 'x-requested-with',
     vary: 'Access-Control-Request-Headers',
     'content-length': '0'
@@ -98,7 +98,7 @@ test('Should reply to preflight requests with custom status code', async t => {
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT,PATCH,POST,DELETE',
+    'access-control-allow-methods': 'GET,HEAD,PUT',
     vary: 'Access-Control-Request-Headers',
     'content-length': '0'
   })
@@ -162,7 +162,7 @@ test('Should reply to all options requests', async t => {
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT,PATCH,POST,DELETE',
+    'access-control-allow-methods': 'GET,HEAD,PUT',
     vary: 'Access-Control-Request-Headers',
     'content-length': '0'
   })
@@ -204,7 +204,7 @@ test('Should support a prefix for preflight requests', async t => {
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT,PATCH,POST,DELETE',
+    'access-control-allow-methods': 'GET,HEAD,PUT',
     vary: 'Access-Control-Request-Headers',
     'content-length': '0'
   })
@@ -329,7 +329,7 @@ test('Should reply to all preflight requests when strictPreflight is disabled', 
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT,PATCH,POST,DELETE',
+    'access-control-allow-methods': 'GET,HEAD,PUT',
     vary: 'Access-Control-Request-Headers',
     'content-length': '0'
   })
@@ -360,7 +360,7 @@ test('Default empty 200 response with preflightContinue on OPTIONS routes', asyn
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT,PATCH,POST,DELETE',
+    'access-control-allow-methods': 'GET,HEAD,PUT',
     vary: 'Access-Control-Request-Headers'
   })
 })
@@ -394,7 +394,7 @@ test('Can override preflight response with preflightContinue', async t => {
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT,PATCH,POST,DELETE',
+    'access-control-allow-methods': 'GET,HEAD,PUT',
     vary: 'Access-Control-Request-Headers'
   })
 })
@@ -429,7 +429,7 @@ test('Should support ongoing prefix ', async t => {
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT,PATCH,POST,DELETE',
+    'access-control-allow-methods': 'GET,HEAD,PUT',
     vary: 'Access-Control-Request-Headers',
     'content-length': '0'
   })
@@ -455,7 +455,7 @@ test('Should support ongoing prefix ', async t => {
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT,PATCH,POST,DELETE',
+    'access-control-allow-methods': 'GET,HEAD,PUT',
     vary: 'Access-Control-Request-Headers',
     'content-length': '0'
   })
@@ -481,7 +481,7 @@ test('Should support ongoing prefix ', async t => {
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT,PATCH,POST,DELETE',
+    'access-control-allow-methods': 'GET,HEAD,PUT',
     vary: 'Access-Control-Request-Headers',
     'content-length': '0'
   })

--- a/test/preflight.test.js
+++ b/test/preflight.test.js
@@ -30,7 +30,7 @@ test('Should reply to preflight requests', async t => {
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT',
+    'access-control-allow-methods': 'GET,HEAD,POST',
     vary: 'Access-Control-Request-Headers',
     'content-length': '0'
   })
@@ -65,7 +65,7 @@ test('Should add access-control-allow-headers to response if preflight req has a
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT',
+    'access-control-allow-methods': 'GET,HEAD,POST',
     'access-control-allow-headers': 'x-requested-with',
     vary: 'Access-Control-Request-Headers',
     'content-length': '0'
@@ -98,7 +98,7 @@ test('Should reply to preflight requests with custom status code', async t => {
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT',
+    'access-control-allow-methods': 'GET,HEAD,POST',
     vary: 'Access-Control-Request-Headers',
     'content-length': '0'
   })
@@ -162,7 +162,7 @@ test('Should reply to all options requests', async t => {
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT',
+    'access-control-allow-methods': 'GET,HEAD,POST',
     vary: 'Access-Control-Request-Headers',
     'content-length': '0'
   })
@@ -204,7 +204,7 @@ test('Should support a prefix for preflight requests', async t => {
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT',
+    'access-control-allow-methods': 'GET,HEAD,POST',
     vary: 'Access-Control-Request-Headers',
     'content-length': '0'
   })
@@ -329,7 +329,7 @@ test('Should reply to all preflight requests when strictPreflight is disabled', 
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT',
+    'access-control-allow-methods': 'GET,HEAD,POST',
     vary: 'Access-Control-Request-Headers',
     'content-length': '0'
   })
@@ -360,7 +360,7 @@ test('Default empty 200 response with preflightContinue on OPTIONS routes', asyn
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT',
+    'access-control-allow-methods': 'GET,HEAD,POST',
     vary: 'Access-Control-Request-Headers'
   })
 })
@@ -394,7 +394,7 @@ test('Can override preflight response with preflightContinue', async t => {
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT',
+    'access-control-allow-methods': 'GET,HEAD,POST',
     vary: 'Access-Control-Request-Headers'
   })
 })
@@ -429,7 +429,7 @@ test('Should support ongoing prefix ', async t => {
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT',
+    'access-control-allow-methods': 'GET,HEAD,POST',
     vary: 'Access-Control-Request-Headers',
     'content-length': '0'
   })
@@ -455,7 +455,7 @@ test('Should support ongoing prefix ', async t => {
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT',
+    'access-control-allow-methods': 'GET,HEAD,POST',
     vary: 'Access-Control-Request-Headers',
     'content-length': '0'
   })
@@ -481,7 +481,7 @@ test('Should support ongoing prefix ', async t => {
   }
   t.assert.deepStrictEqual(actualHeaders, {
     'access-control-allow-origin': '*',
-    'access-control-allow-methods': 'GET,HEAD,PUT',
+    'access-control-allow-methods': 'GET,HEAD,POST',
     vary: 'Access-Control-Request-Headers',
     'content-length': '0'
   })


### PR DESCRIPTION
Closes #358.

This is a breaking change and will require a semver major release.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
