### PR TITLE
Feat/preflight add `logLevel` option to silence CORS preflight logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ You can use it as is without passing any option or you can configure it as expla
 * `preflight`: Disables preflight by passing `false`. Default: `true`.
 * `strictPreflight`: Enforces strict requirements for the CORS preflight request headers (**Access-Control-Request-Method** and **Origin**) as defined by the [W3C CORS specification](https://www.w3.org/TR/2020/SPSD-cors-20200602/#resource-preflight-requests). Preflight requests without the required headers result in 400 errors when set to `true`. Default: `true`.
 * `hideOptionsRoute`: Hides the options route from documentation built using [@fastify/swagger](https://github.com/fastify/fastify-swagger). Default: `true`.
+* `logLevel`: Sets the Fastify log level **only** for the internal CORS pre-flight `OPTIONS *` route.  
+  Pass `'silent'` to suppress these requests in your logs, or any valid Fastify
+  log level (`'trace'`, `'debug'`, `'info'`, `'warn'`, `'error'`, `'fatal'`).  
+  Default: inherits Fastify’s global log level.
 
 #### :warning: DoS attacks
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,8 @@ const defaultOptions = {
   allowedHeaders: null,
   maxAge: null,
   preflight: true,
-  strictPreflight: true
+  strictPreflight: true,
+  logLevel: null
 }
 
 const validHooks = [
@@ -46,6 +47,11 @@ function fastifyCors (fastify, opts, next) {
   fastify.decorateRequest('corsPreflightEnabled', false)
 
   let hideOptionsRoute = true
+  let routeLogLevel = null
+
+  if (opts && typeof opts === 'object' && opts.logLevel !== undefined) {
+    routeLogLevel = opts.logLevel
+  }
   if (typeof opts === 'function') {
     handleCorsOptionsDelegator(opts, fastify, { hook: defaultOptions.hook }, next)
   } else if (opts.delegator) {
@@ -72,7 +78,8 @@ function fastifyCors (fastify, opts, next) {
   // remove most headers (such as the Authentication header).
   //
   // This route simply enables fastify to accept preflight requests.
-  fastify.options('*', { schema: { hide: hideOptionsRoute } }, (req, reply) => {
+
+  fastify.options('*', { schema: { hide: hideOptionsRoute }, ...(routeLogLevel !== null && { logLevel: routeLogLevel }) }, (req, reply) => {
     if (!req.corsPreflightEnabled) {
       // Do not handle preflight requests if the origin option disabled CORS
       reply.callNotFound()

--- a/index.js
+++ b/index.js
@@ -17,8 +17,7 @@ const defaultOptions = {
   allowedHeaders: null,
   maxAge: null,
   preflight: true,
-  strictPreflight: true,
-  logLevel: null
+  strictPreflight: true
 }
 
 const validHooks = [

--- a/test/preflight.test.js
+++ b/test/preflight.test.js
@@ -529,3 +529,62 @@ test('Silences preflight logs when logLevel is "silent"', async t => {
 
   await fastify.close()
 })
+test('delegator + logLevel:"silent" → OPTIONS logs are suppressed', async t => {
+  t.plan(3)
+
+  const logs = []
+  const app = Fastify({
+    logger: {
+      level: 'info',
+      stream: { write: l => { try { logs.push(JSON.parse(l)) } catch {} } }
+    }
+  })
+
+  await app.register(cors, {
+    delegator: () => ({ origin: '*' }),
+    logLevel: 'silent'
+  })
+
+  app.get('/', () => ({ ok: true }))
+  await app.ready()
+  t.assert.ok(app)
+
+  await app.inject({
+    method: 'OPTIONS',
+    url: '/',
+    headers: {
+      'access-control-request-method': 'GET',
+      origin: 'https://example.com'
+    }
+  })
+
+  await app.inject({ method: 'GET', url: '/' })
+
+  const hasOptionsLog = logs.some(l => l.req?.method === 'OPTIONS')
+  const hasGetLog = logs.some(l => l.req?.method === 'GET')
+
+  t.assert.strictEqual(hasOptionsLog, false)
+  t.assert.strictEqual(hasGetLog, true)
+
+  await app.close()
+})
+test('delegator + hideOptionsRoute:false → OPTIONS route is visible', async t => {
+  t.plan(2)
+
+  const app = Fastify()
+
+  app.addHook('onRoute', route => {
+    if (route.method === 'OPTIONS' && route.url === '*') {
+      t.assert.strictEqual(route.schema.hide, false)
+    }
+  })
+
+  await app.register(cors, {
+    delegator: () => ({ origin: '*' }),
+    hideOptionsRoute: false
+  })
+
+  await app.ready()
+  t.assert.ok(app)
+  await app.close()
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-import { FastifyInstance, FastifyPluginCallback, FastifyRequest } from 'fastify'
+import { FastifyInstance, FastifyPluginCallback, FastifyRequest, LogLevel } from 'fastify'
 
 type OriginCallback = (err: Error | null, origin: ValueOrArray<OriginType>) => void
 type OriginType = string | boolean | RegExp
@@ -107,7 +107,7 @@ declare namespace fastifyCors {
      * Useful for reducing noise in application logs.
      * Default: inherits Fastify's global log level.
       */
-    logLevel?: import('fastify').LogLevel;
+    logLevel?: LogLevel;
   }
 
   export interface FastifyCorsOptionsDelegateCallback { (req: FastifyRequest, cb: (error: Error | null, corsOptions?: FastifyCorsOptions) => void): void }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -99,6 +99,15 @@ declare namespace fastifyCors {
      * Hide options route from the documentation built using fastify-swagger (default: true).
      */
     hideOptionsRoute?: boolean;
+
+    /**
+     * Sets the Fastify log level specifically for the internal OPTIONS route
+     * used to handle CORS preflight requests. For example, setting this to `'silent'`
+     * will prevent these requests from being logged.
+     * Useful for reducing noise in application logs.
+     * Default: inherits Fastify's global log level.
+      */
+    logLevel?: import('fastify').LogLevel;
   }
 
   export interface FastifyCorsOptionsDelegateCallback { (req: FastifyRequest, cb: (error: Error | null, corsOptions?: FastifyCorsOptions) => void): void }

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -165,7 +165,8 @@ appHttp2.register(fastifyCors, {
   preflightContinue: false,
   optionsSuccessStatus: 200,
   preflight: false,
-  strictPreflight: false
+  strictPreflight: false,
+  logLevel: 'silent'
 })
 
 appHttp2.register(fastifyCors, {


### PR DESCRIPTION
This PR introduces an optional logLevel field to FastifyCorsOptions, letting users override the Fastify logger level for the internal OPTIONS * pre-flight route.
- Adds logLevel to default options and TypeScript typings
- Applies level when registering the pre-flight route
- New unit test verifies OPTIONS logs are suppressed, GET logs remain
- README/types comments updated accordingly

fixes: #320 




#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
