### PR TITLE
chore(.gitattributes): retain binary file eol style

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,2 @@
-# Set the default behavior, in case people don't have core.autocrlf set
-* text=auto
-
-# Require Unix line endings
-* text eol=lf
+# Set default behavior to automatically convert line endings
+* text=auto eol=lf


### PR DESCRIPTION
Spotted thanks to https://github.com/fastify/fastify-swagger-ui/pull/269.

`.gitattributes` is processed line by line, so the second line overrides the first, meaning every file that matches the `*` wildcard was treated as text and forced to have an eol of `lf`.

With this corrected attributes file, only automatically detected text files have an `lf` eol, whilst binaries remain untouched. See https://git-scm.com/docs/gitattributes#_effects

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
